### PR TITLE
Utils update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Simply run ```nix shell github:BirdeeHub/nixCats-nvim``` and run nvim to read it
 
 This is because there is (reasonable) syntax highlighting for the code examples in the help when viewed within nvim.
 
+There is about as much help as there is nix code in this entire project.
+
     An important note: if you add a file,
     nix will not package it unless you add it 
     to your git staging before you build it...

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Let me know when you figure it out I'm kinda a nix noob still. [How to contribut
 
 Mason does not work on nixOS although it does on other OS options.
 
-This is a general nix thing, not specific to this project.
+These are general nix things, not specific to this project.
 
 ---
 
@@ -294,6 +294,3 @@ I also borrowed some code from nixpkgs and included links.
 - [`Luca's super simple`](https://github.com/Quoteme/neovim-flake):
   Definitely the simplest example I have seen thus far. I took it and ran with it, read a LOT of docs and nixpkgs source code and then made this.
   I mentioned it above in the special mentions. As someone with no exposure to functional programming, such a simple example was absolutely fantastic.
-- [`andromeda-neovim`](https://github.com/lecoqjacob/andromeda-neovim):
-A repo which took an early version of nixCats and added many things to it such as a nix wrapper for lazy, at the cost of losing the simplistic design and the help.
-It made me happy to see people taking inspiration from my work, so I added it to the list.

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1701432845,
-        "narHash": "sha256-06sd2rQ+DPMSueh+hW4MiXbpMSdhQHJOi/sw0vuwqvs=",
+        "lastModified": 1701693815,
+        "narHash": "sha256-7BkrXykVWfkn6+c1EhFA3ko4MLi3gVG0p9G96PNnKTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "77da99a144cd341408308e0a37622f5edcc6c5ba",
+        "rev": "09ec6a0881e1a36c29d67497693a67a16f4da573",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
       # Now that our plugin inputs/overlays and pkgs have been defined,
       # We define a function to facilitate package building for particular categories
       # to do this it imports ./builder/default.nix, passing it our information.
-      # This allows us to define categories and settings for or package later and then choose a package.
+      # This allows us to define categories and settings for our package later and then choose a package.
 
       # see :help nixCats.flake.outputs.builder
       # If you dont want nixCatsHelp in your root directory

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,10 @@
       # This allows us to define categories and settings for or package later and then choose a package.
 
       # see :help nixCats.flake.outputs.builder
+      # If you dont want nixCatsHelp in your root directory
+      # it is safe to simply change the relative path here.
+      # you could also just import the baseBuilder straight from nixCats github
+      # see :help nixCats.installation_options.advanced for more details on that.
       baseBuilder = import ./builder "${self}/nixCatsHelp";
       nixCatsBuilder = baseBuilder self pkgs
         # notice how it doesn't care that these are defined lower in the file?
@@ -80,7 +84,7 @@
         # to define and use a new category, simply add a new list to a set here, 
         # and later, you will include categoryname = true; in the set you
         # provide when you build the package using this builder function.
-        # see :help nixCats.flake.outputs.packaging for info on that section.
+        # see :help nixCats.flake.outputs.packageDefinitions for info on that section.
 
         # propagatedBuildInputs:
         # this section is for dependencies that should be available
@@ -123,8 +127,10 @@
             neodev-nvim
             neoconf-nvim
           ];
-          markdown = with pkgs.nixCatsBuilds; [
-            markdown-preview-nvim
+          # yes these category names are arbitrary
+          markdown = with pkgs.vimPlugins; [
+            # yes it knows this isn't with pkgs.vimPlugins
+            pkgs.nixCatsBuilds.markdown-preview-nvim
           ];
           gitPlugins = with pkgs.neovimPlugins; [
             hlargs
@@ -186,6 +192,13 @@
                 "tokyonight-day" = tokyonight-nvim;
               }
             )
+            # This is obviously a fairly basic usecase for this, but still nice.
+            # Better would be something like:
+            # language specific packaging that still keeps debuggers in the debugger category
+            # or excluding something within a category from only one or 2 packages.
+
+            # Checking packageDefinitions also has the bonus
+            # of being able to be easily set by importing flakes.
           ];
         };
 
@@ -343,10 +356,12 @@
         fresh = baseBuilder;
         keepLua = baseBuilder self;
       };
+      inherit utils;
 
+      # and you export this so people dont have to redefine stuff.
       inherit otherOverlays;
       inherit categoryDefinitions;
-      inherit utils;
+      inherit packageDefinitions;
 
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,5 @@
 # Copyright (c) 2023 BirdeeHub
 # Licensed under the MIT license
-# Only 3 files are marked with this header.
-# Please leave them in.
 {
   description = "A Lua-natic's neovim flake, with extra cats! nixCats!";
 

--- a/flake.nix
+++ b/flake.nix
@@ -201,7 +201,7 @@
         };
 
         # not loaded automatically at startup.
-        # use with packadd in config to achieve something like lazy loading
+        # use with packadd and an autocommand in config to achieve lazy loading
         optionalPlugins = {
           custom = with pkgs.nixCatsBuilds; [ ];
           gitPlugins = with pkgs.neovimPlugins; [ ];

--- a/nixCatsHelp/installation.txt
+++ b/nixCatsHelp/installation.txt
@@ -24,15 +24,18 @@ as you then only have to restart it rather than rebuild.
 However that also means the regularCats package must be cloned locally.
 
 You should clone regularCats to your ~/.config/ directory and 
-make sure the filename is <nixCats-nvim> so that you 
-can still keep everything in the same place when you do this.
+make sure the filename is nixCats-nvim, set via configDirName,
+so that you can still keep everything in the same place when you do this.
 
 If it is named something else, you will have to change configDirName
 in the settings section of flake.nix, or the name of the directory. 
 This also affects .local and the like.
 
-These are the basic options you export,
-using customPackager, packages and overlays:
+These are the basic options you export.
+However there are many more ways to do it. This is just a few.
+
+You could run nix build on a flake.nix containing this.
+It would produce 4 configured neovim packages.
 
 >nix
   {
@@ -53,7 +56,7 @@ using customPackager, packages and overlays:
           };
           # this is the equivalent of the nixCats package
           # but with a different colorscheme
-          customVimPackager = nixCats-nvim.customPackager.${system} packageDefinitions;
+          customVimBuilder = nixCats-nvim.customPackager.${system} packageDefinitions;
           packageDefinitions = {
             customvim = {
               settings = {
@@ -78,7 +81,6 @@ using customPackager, packages and overlays:
                 # you could also pass something else:
                 colorscheme = "catppuccin";
                 # you could :lua print(vim.inspect(require('nixCats')))
-                # I got carried away and it worked FIRST TRY.
                 # see :help nixCats
               };
             };
@@ -88,7 +90,7 @@ using customPackager, packages and overlays:
               packages.default = nixCats-nvim.packages.${system}.nixCats;
               packages.nixCats = pkgs.nixCats;
               packages.regularCats = pkgs.regularCats;
-              packages.customvim = customVimPackager "customvim";
+              packages.customvim = customVimBuilder "customvim";
           }
       );
   }
@@ -96,9 +98,15 @@ using customPackager, packages and overlays:
 
 ---------------------------------------------------------------------------------------
                                        *nixCats.installation_options.advanced*
-This is a showcase of the various utils and builders 
+
+This is a showcase of most of the various utils and builders 
 that get exported and how to use them.
-You could run nixBuild on a flake.nix containing only the following.
+You could run nix build on a standalone flake.nix file containing only the following.
+
+It would export all the same configurations and exported options as the original 
+but with an extra plugin and a new colorscheme.
+Although its wrapRc option is not useful since the lua is not locally present.
+So it does not export the regularCats package.
 
 >nix
   # Copyright (c) 2023 BirdeeHub
@@ -123,9 +131,11 @@ You could run nixBuild on a flake.nix containing only the following.
       flake-utils.lib.eachDefaultSystem (system: let
         utils = nixCats.utils.${system};
 
-        # you may use mergeOverlayLists to merge otherOverlays from other nixCats flakes
+        # Here we use mergeOverlayLists to merge otherOverlays from other nixCats flakes
+        # feel free to not do that and just include a list of overlays.
+        # you may uncomment the import statement to include an overlays directory
         otherOverlays = [ (utils.mergeOverlayLists nixCats.otherOverlays.${system}
-        ( /* (import ./overlays inputs) ++ */ # <-- you may uncomment this if desired
+        ( /* (import ./overlays inputs) ++ */ 
           [
             # add any flake overlays here.
           ]
@@ -133,27 +143,23 @@ You could run nixBuild on a flake.nix containing only the following.
         pkgs = import nixpkgs {
           inherit system;
           overlays = otherOverlays ++ [
+              # here we can also add the regular inputs from other nixCats like so
               (utils.standardPluginOverlay (nixCats.inputs // inputs))
             ];
           # config.allowUnfree = true;
         };
 
-        # Now that our plugin inputs/overlays and pkgs have been defined,
-        # We define a function to facilitate package building for particular categories
-        # to do this it imports ./builder/default.nix, passing it our information.
-        # This allows us to define categories and settings for 
-        # our package later and then choose a package.
-
         # see :help nixCats.flake.outputs.builder
         baseBuilder = nixCats.customBuilders.${system}.fresh;
 
-        # you could optionally define your own lua, but here we import it.
         # nixCatsBuilder = baseBuilder self pkgs categoryDefinitions packageDefinitions;
+        # you could optionally define your own lua like above, but here we import it.
         nixCatsBuilder = nixCats.customBuilders.${system}.keepLua pkgs
           categoryDefinitions packageDefinitions;
 
         # see :help nixCats.flake.outputs.categories
-          # I am using the utils.mergeCatDefs option to add a new category
+          # I am using the utils.mergeCatDefs option 
+          # to add a new category without redefining the whole set.
           # if you edit an existing category name, your category will overwrite
           # the entire old category with that name.
 
@@ -176,48 +182,27 @@ You could run nixBuild on a flake.nix containing only the following.
           }
         );
 
-        # see :help nixCats.flake.outputs.settings
-        settings = {
-          nixCats = {
-            wrapRc = true;
-            configDirName = "nixCats-nvim";
-            viAlias = false;
-            vimAlias = true;
-          };
-        };
-
         # see :help nixCats.flake.outputs.packageDefinitions
         packageDefinitions = {
           nixCats = {
-            settings = settings.nixCats; 
-            categories = {
-              generalBuildInputs = true;
-              markdown = true;
-              gitPlugins = true;
-              general = true;
-              custom = true;
-              neonixdev = true;
-              test = true;
-              debug = false;
-              # this does not have an associated category of plugins, 
-              # but lua can still check for it
-              lspDebugMode = false;
-              # you could also pass something else:
-              eyeliner = true;
-              themer = true;
-              colorscheme = "tokyonight";
-            };
+            settings = nixCats.packageDefinitions.${system}.nixCats.settings;
+            categories = 
+              nixCats.packageDefinitions.${system}.nixCats.categories 
+              // {
+                eyeliner = true;
+                colorscheme = "tokyonight";
+              };
           };
         };
       in
-
-
 
       # see :help nixCats.flake.outputs.exports
       {
 
         # this will make a package out of each of the packageDefinitions defined above
         # and set the default package to the one named here.
+        # However, this flake only outputs 1 package so its not super needed.
+        # its an example, ok?
         packages = utils.mkPackages nixCatsBuilder packageDefinitions "nixCats";
 
         # this will make an overlay out of each of the packageDefinitions defined above
@@ -241,13 +226,16 @@ You could run nixBuild on a flake.nix containing only the following.
         # You may use these to modify some or all of your categoryDefinitions
         customBuilders = {
           fresh = baseBuilder;
+          # this has no lua files to include, so instead of
           # keepLua = baseBuilder self;
+          # we instead use this to pass on the other lua we inherited
           keepLua = nixCats.customBuilders.${system}.keepLua;
         };
+        inherit utils;
 
         inherit otherOverlays;
         inherit categoryDefinitions;
-        inherit utils;
+        inherit packageDefinitions;
 
       }
 

--- a/nixCatsHelp/nixCatsFlake.txt
+++ b/nixCatsHelp/nixCatsFlake.txt
@@ -56,6 +56,9 @@ i.e. an lsp, dont name them in that format.
 If they are on nixpkgs, you dont necessarily need to put them in inputs,
 because you will be able to access them through pkgs.vimPlugins variable later.
 
+Most plugins will not require you to use this section due to being on nixpkgs.
+But you may still use it to pin the plugin to a specific version.
+
 Context for later:
 
 If they have a build step, you will deal with them in overlays/customBuildsOverlay.nix
@@ -211,6 +214,10 @@ github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper
 
 how this function actually works is covered in 
 :help `nixCats.flake.nixperts.nvimBuilder`
+In essence, the contents of each set listed here are filtered
+based on the packageDefinitions set you provide, 
+where by including categoryname = true; you enable that category.
+:help `nixCats.flake.outputs.packageDefinitions`
 
 ---------------------------------------------------------------------------------------
 Settings Profiles:                             *nixCats.flake.outputs.settings*
@@ -306,68 +313,121 @@ see :help `nixCats`
 Flake Exports and Export options               *nixCats.flake.outputs.exports*
 
 First, we define our packages.
-We use utils.mkPackages to do this. 
+We can use utils.mkPackages to do this. 
 It allows us to choose a default package, and
 then it also exports all of them by name to choose from separately.
 
 Then we define our overlays, using utils.mkOverlay to do this for the same reason.
+utils.mkOverlay also makes a default overlay, and then 1 overlay per package.
 
 Then we define our dev shell. We simply use our nixCatsBuilder for this one.
+>nix
+  packages = utils.mkPackages nixCatsBuilder packageDefinitions "nixCats";
 
-After that, there are some options for flakes that import this flake.
-Using these functions, you can import this flake in your inputs,
-and then use the builder and the help in another flake.
+  overlays = utils.mkOverlays nixCatsBuilder packageDefinitions "nixCats";
 
-First, customPackager. This would allow you to choose what
-settings and categories you wanted in a flake that imports this flake,
-without needing to redefine anything else.
+  devShell = pkgs.mkShell {
+    name = "nixCats-devShell";
+    packages = [ (nixCatsBuilder "nixCats") ];
+    inputsFrom = [ ];
+    shellHook = ''
+    '';
+  };
+<
+Now for the required exports for nix integration options.
 
-Then customBuilders. These are just baseBuilder, exported both with and
-without a lua path already supplied.
-
-Then otherOverlays. These are a list of all overlays 
-that you imported that are not standardPluginOverlay.
-You may use utils.mergeOverlayLists to incorporate overlays 
-from other nixCats flakes without worrying about naming conflicts.
-Should you do this you should follow the example in the advanced_installation
-branch of the repo for this secion so that others may reliably do this too.
-
-Then categoryDefinitions. The function where you set up your categories in flake.nix
-
-Then last, the utils set, which we imported from ./builder/utils.nix
-
-In total, the utils set contains 5 functions
-
-First, mkPackages, mkOverlays and standardPluginOverlay, all mentioned above.
-In addition to those, there is also 2 convenience functions:
-mergeCatDefs for merging category definitions,
-and mergeOverlayLists for merging lists of overlays like those in otherOverlays in a way 
-that updates to avoid naming conflicts between overlays in different nixCats flakes imported.
-
-
-
-When making your own nixCats flake, it is highly recommended to add the same
-outputs as this flake.nix. So, to restate, here they all are.
-
-In addition to its packages, overlays, and devShell,
-and whatever other regular flake outputs you wish to export,
-every nixCats flake should include in its outputs:
-
-  The customPackager, which is a builder without a packageDefinitions set yet,
-
-  Both of the customBuilders, which are 'baseBuilder's with and without a lua path,
-
-  Its otherOverlays, which are all overlays that are not standardPluginOverlay,
-
-  Its categoryDefinitions function, 
-
-  The utils set inherited from previous nixCats flakes or the utils.nix file.
-
-That way, you can always export all of the same customization options to new
+They allow you to always export all of the same customization options to new
 flakes as the original one has, but for your own flake.
 
 for information on how to use these options when importing your nixCats flake,
 see :help `nixCats.installation_options`
+
+They look like this:
+>nix
+  # To choose settings and categories from the flake that calls this flake.
+  customPackager = baseBuilder self pkgs categoryDefinitions;
+
+  # You may use these to modify some or all of your categoryDefinitions
+  customBuilders = {
+    fresh = baseBuilder;
+    keepLua = baseBuilder self;
+  };
+  inherit utils;
+
+  inherit otherOverlays;
+  inherit categoryDefinitions;
+  inherit packageDefinitions;
+<
+
+First, <customPackager>. This would allow you to choose what
+settings and categories you wanted in a flake that imports this flake,
+without needing to redefine anything else.
+
+Then <customBuilders>. These are just baseBuilder, exported both with and
+without a lua path already supplied.
+You could import the fresh builder and utils straight from nixCats, 
+alowing you to be free of personally including the builder and nixCatsHelp directories,
+allowing you to use those but otherwise have a fresh start.
+
+Then <otherOverlays>. These are a list of all overlays 
+that you imported that are not standardPluginOverlay.
+You may use utils.mergeOverlayLists to incorporate overlays 
+from other nixCats flakes without worrying about naming conflicts.
+When creating your flake, make sure to follow the format shown
+in :help `nixCats.installation_options.advanced` 
+when importing overlays to your pkgs set.
+That format is not very complex. The format is this.
+1. Make a list called otherOverlays.
+2. Put every overlay that isn't standardPluginOverlay in there.
+3. when you add overlays to pkgs, 
+    use ++ to add otherOverlays to a list containing
+    the call to standardPluginOverlay.
+This allows you to be able to export otherOverlays
+at the end in the final outputs because it is separate.
+
+Then <categoryDefinitions>
+The function where you set up your categories in flake.nix
+This allows importing flakes to do a lot less copy pasting.
+
+Then <packageDefinitions>
+The set where you chose categories and settings for each package.
+This allows importing flakes to do a lot less copy pasting.
+
+
+
+Then last, the <utils> set, which we imported from ./builder/utils.nix
+
+In total, the <utils> set contains 8 functions
+
+First, the ones mentioned above.
+
+<mkPackages> finalBuilder: packageDefinitions: defaultName:
+makes each package and also a default one
+
+<mkOverlays> finalBuilder: packageDefinitions: defaultName:
+makes an overlay for each package and also a default one
+
+<standardPluginOverlay> inputs:
+allows for inputs named plugins-something to be
+turned into an overlay containing them as plugins automatically
+
+In addition to those, there is also 5 convenience functions:
+
+<mergeCatDefs> pkgs: oldCats: newCats:
+for merging category definitions,
+
+<mergeOverlayLists> oldOverlist: newOverlist: self: super: let
+for merging lists of overlays like those in otherOverlays in a way 
+that updates to avoid naming conflicts between overlays in different nixCats flakes imported.
+
+<mkDefaultOverlay> finalBuilder: defaultName:
+<mkExtraOverlays> finalBuilder: packageDefinitions:
+which when combined with // make up mkOverlays
+
+<mkMultiOverlay> finalBuilder: packageDefinitions: importName: namesIncList:
+Instead of taking a name, it takes an importName and a list of names.
+It will output them in an overlay accessible by pkgs.${importName}.${name}
+
 
 ---------------------------------------------------------------------------------------
 vim:tw=78:ts=8:ft=help:norl:

--- a/overlays/customBuildsOverlay.nix
+++ b/overlays/customBuildsOverlay.nix
@@ -2,8 +2,10 @@ importName: inputs: let
   overlay = self: super: { 
     ${importName} = {
 
-      # reddit user bin-c found this link for me,
+      # I needed to do this because the one on nixpkgs wasnt working
+      # reddit user bin-c found this link for me.
       # and I adapted the funtion to my overlay
+      # It is the entry from nixpkgs.
       # https://github.com/NixOS/nixpkgs/blob/44a691ec0cdcd229bffdea17455c833f409d274a/pkgs/applications/editors/vim/plugins/overrides.nix#L746
       markdown-preview-nvim =  let
         nodeDep = super.yarn2nix-moretea.mkYarnModules rec {


### PR DESCRIPTION
flake.nix changes:
Added packageDefinitions to the list of things output by this flake with ```inherit packageDefinitions;```
This should allow for much less copy pasting when using customPackager
This is a 1 line addition. It is the only important change to flake.nix

Other miscellaneous comment additions to flake.nix, as well as 1 change that illustrates the nuances of the nix ```with pkgs.something``` syntax but changes nothing.

builder/utils file:

Added 1 util to the exported utils set, allowing for easy creation of an overlay containing multiple neovim packages.

Made utils.mkOverlays into a composition of 2 other functions, and also added them to the utils set already being exported.

Comment additions

Other than that, the only things changed were improvements and additions to readme and help.