### PR TITLE
v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is not a lua showcase. You are meant to use your own lua once you unde
 It is aimed at people who know enough lua to comfortably proceed from a kickstarter level setup
 who want to swap to using nix while still using lua for configuration.
 
-For 95% of plugins and lsps, you won't need to do more than add plugin names to lists you make in flake.nix,
+For 95% of plugins and lsps, you won't need to do more than add plugin names to categories you make in flake.nix,
 
 then configure in lua using lspconfig or the regular setup or config functions provided by the plugin.
 
@@ -18,8 +18,6 @@ except with the bonus of being able to install and set up more than just neovim 
 It also allows for easy project specific packaging using nixCats for all the cool direnv stuff.
 
 You can require('nixCats') for what nix categories you created are included in the current package.
-
-The categories are the lists you created that you added plugins to.
 
 Doing so allows you to define as many different packages as you want from the same config file.
 

--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702206697,
-        "narHash": "sha256-vE9oEx3Y8TO5MnWwFlmopjHd1JoEBno+EhsfUCq5iR8=",
+        "lastModified": 1702272962,
+        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29d6c96900b9b576c2fb89491452f283aa979819",
+        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     "plugins-hlargs": {
       "flake": false,
       "locked": {
-        "lastModified": 1694799735,
-        "narHash": "sha256-bH0OOf5T4Z96Td4ZBV1q8DI/bO1pV8DwqEWho6jeggg=",
+        "lastModified": 1702317151,
+        "narHash": "sha256-AgHETTIsDOLgEnEaFWq1kXY+Ye/DUU6W+95M37VNOVw=",
         "owner": "m-demare",
         "repo": "hlargs.nvim",
-        "rev": "6218a401824c5733ac50b264991b62d064e85ab2",
+        "rev": "872c332dcc65324604011fa6056c4d71253e399b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,8 @@
         categoryDefinitions packageDefinitions;
 
       # see :help nixCats.flake.outputs.categories
+      # and
+      # :help nixCats.flake.outputs.categoryDefinitions.scheme
       categoryDefinitions = packageDef: {
         # to define and use a new category, simply add a new list to a set here, 
         # and later, you will include categoryname = true; in the set you
@@ -235,11 +237,13 @@
           ];
         };
 
+        # lists of the functions you would have passed to
+        # python.withPackages or lua.withPackages
         extraPythonPackages = {
-          test = [ (_:[]) ];
+          test = (_:[]);
         };
         extraPython3Packages = {
-          test = [ (_:[]) ];
+          test = (_:[]);
         };
         extraLuaPackages = {
           test = [ (_:[]) ];

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
       # This allows us to define categories and settings for our package later and then choose a package.
 
       # see :help nixCats.flake.outputs.builder
-      # If you dont want nixCatsHelp in your root directory
+      # If you dont want nixCatsHelp in that directory
       # it is safe to simply change the relative path here.
       # you could also just import the baseBuilder straight from nixCats github
       # see :help nixCats.installation_options.advanced for more details on that.
@@ -110,14 +110,12 @@
             ripgrep
             fd
           ];
-          neonixdev = with pkgs; [
+          neonixdev = {
+            # also you can do this.
+            inherit (pkgs) nix-doc nil lua-language-server nixd;
             # nix-doc tags will make your tags much better in nix
             # but only if you have nil as well for some reason
-            nix-doc
-            nil
-            lua-language-server
-            nixd
-          ];
+          };
         };
 
         # This is for plugins that will load at startup without using packadd:
@@ -136,57 +134,62 @@
             # yes it knows this isn't with pkgs.vimPlugins
             pkgs.nixCatsBuilds.markdown-preview-nvim
           ];
-          gitPlugins = with pkgs.neovimPlugins; [
-            hlargs
-            fidget
-          ];
-          general = with pkgs.vimPlugins; [
-            telescope-fzf-native-nvim
-            plenary-nvim
-            telescope-nvim
-            # treesitter
-            nvim-treesitter-textobjects
-            nvim-treesitter.withAllGrammars
-            # This is for if you only want some of the grammars
-            # (nvim-treesitter.withPlugins (
-            #   plugins: with plugins; [
-            #     nix
-            #     lua
-            #   ]
-            # ))
-            # cmp stuff
-            nvim-cmp
-            luasnip
-            friendly-snippets
-            cmp_luasnip
-            cmp-buffer
-            cmp-path
-            cmp-nvim-lua
-            cmp-nvim-lsp
-            cmp-cmdline
-            cmp-nvim-lsp-signature-help
-            cmp-cmdline-history
-            lspkind-nvim
-            # other
-            nvim-lspconfig
-            lualine-nvim
-            gitsigns-nvim
-            which-key-nvim
-            comment-nvim
-            vim-sleuth
-            vim-fugitive
-            vim-rhubarb
-            vim-repeat
-            undotree
-            nvim-surround
-            indent-blankline-nvim
-            nvim-web-devicons
-          ];
-          themer = with pkgs.vimPlugins; [
-            # You can retreive information from the
-            # packageDefinitions of the package this was packaged with.
-            # you can use it to create something like subcategories
-            # that could still be set by customPackager
+          general = {
+            gitPlugins = with pkgs.neovimPlugins; [
+              hlargs
+              fidget
+            ];
+            vimPlugins = {
+              # now you can actually subcategory
+              cmp = with pkgs.vimPlugins; [
+                # cmp stuff
+                nvim-cmp
+                luasnip
+                friendly-snippets
+                cmp_luasnip
+                cmp-buffer
+                cmp-path
+                cmp-nvim-lua
+                cmp-nvim-lsp
+                cmp-cmdline
+                cmp-nvim-lsp-signature-help
+                cmp-cmdline-history
+                lspkind-nvim
+              ];
+              general = with pkgs.vimPlugins; [
+                telescope-fzf-native-nvim
+                plenary-nvim
+                telescope-nvim
+                # treesitter
+                nvim-treesitter-textobjects
+                nvim-treesitter.withAllGrammars
+                # This is for if you only want some of the grammars
+                # (nvim-treesitter.withPlugins (
+                #   plugins: with plugins; [
+                #     nix
+                #     lua
+                #   ]
+                # ))
+                # other
+                nvim-lspconfig
+                lualine-nvim
+                gitsigns-nvim
+                which-key-nvim
+                comment-nvim
+                vim-sleuth
+                vim-fugitive
+                vim-rhubarb
+                vim-repeat
+                undotree
+                nvim-surround
+                indent-blankline-nvim
+                nvim-web-devicons
+              ];
+            };
+          };
+          # You can retreive information from the
+          # packageDefinitions of the package this was packaged with.
+          themer = with pkgs.vimPlugins;
             (builtins.getAttr packageDef.categories.colorscheme {
                 # Theme switcher without creating a new category
                 "onedark" = onedark-vim;
@@ -195,14 +198,10 @@
                 "tokyonight" = tokyonight-nvim;
                 "tokyonight-day" = tokyonight-nvim;
               }
-            )
+            );
             # This is obviously a fairly basic usecase for this, but still nice.
-            # Better would be something like:
-            # language specific packaging that still keeps debuggers in the debugger category
-
             # Checking packageDefinitions also has the bonus
             # of being able to be easily set by importing flakes.
-          ];
         };
 
         # not loaded automatically at startup.
@@ -218,7 +217,12 @@
         # at RUN TIME for plugins. Will be available to path within neovim terminal
         environmentVariables = {
           test = {
-            CATTESTVAR = "It worked!";
+            subtest1 = {
+              CATTESTVAR = "It worked!";
+            };
+            subtest2 = {
+              CATTESTVAR3 = "It didn't work!";
+            };
           };
         };
 
@@ -277,11 +281,13 @@
           categories = {
             generalBuildInputs = true;
             markdown = true;
-            gitPlugins = true;
-            general = true;
+            general.vimPlugins = true;
+            general.gitPlugins = true;
             custom = true;
             neonixdev = true;
-            test = true;
+            test = {
+              subtest1 = true;
+            };
             debug = false;
             # this does not have an associated category of plugins, 
             # but lua can still check for it
@@ -309,7 +315,6 @@
           categories = {
             generalBuildInputs = true;
             markdown = true;
-            gitPlugins = true;
             general = true;
             custom = true;
             neonixdev = true;

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,5 @@
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
-print("TESTING")
 
 -- [[ Setting options ]]
 -- See `:help vim.o`

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
+print("TESTING")
 
 -- [[ Setting options ]]
 -- See `:help vim.o`

--- a/nix/nixCatsHelp/nixCats.txt
+++ b/nix/nixCatsHelp/nixCats.txt
@@ -116,6 +116,8 @@ Note: it also accepts other things.
 lists will become arrays
 sets will become tables
 null will become nil
+If your attribute had a name illegal in lua,
+you may access your attribute with require('nixCats')["attr-name!"] syntax
 
 everything that isnt true, false, null, 
 a list, or a set becomes a lua string.

--- a/nix/nixCatsHelp/nixCatsFlake.txt
+++ b/nix/nixCatsHelp/nixCatsFlake.txt
@@ -463,8 +463,9 @@ turned into an overlay containing them as plugins automatically
 
 In addition to those, there is also 5 convenience functions:
 
-<mergeCatDefs> pkgs: oldCats: newCats:
+<mergeCatDefs> oldCats: newCats:
 for merging category definitions,
+will recursively update up to the first thing not an attrset
 
 <mergeOverlayLists> oldOverlist: newOverlist: self: super: let
 for merging lists of overlays like those in otherOverlays in a way 

--- a/nix/nixCatsHelp/nixCatsFlake.txt
+++ b/nix/nixCatsHelp/nixCatsFlake.txt
@@ -182,21 +182,21 @@ These are the things you can return:
   categoryDefinitions = packageDef: {
 <
 <propagatedBuildInputs> 
-  a flexible set of categories, each containing a list of 
-  internal BUILD TIME dependencies. Will also be available to the devShell.
+  a flexible set of categories, each containing internal
+  BUILD TIME dependencies. Will also be available to the devShell.
 
 <lspsAndRuntimeDeps>
-  a flexible set of categories, each containing a list of LSP's or 
+  a flexible set of categories, each containing LSP's or 
   other internal runtime dependencies such as ctags or debuggers
   these are available to the PATH while within the neovim program.
   this includes the neovim terminal.
 
 <startupPlugins>
-  a flexible set of categories, each containing a list of startup plugins.
+  a flexible set of categories, each containing startup plugins.
   Startup plugins are loaded and can be required. 
 
 <optionalPlugins>
-  a flexible set of categories, each containing a list of optional plugins.
+  a flexible set of categories, each containing optional plugins.
   Optional plugins need to be added with packadd before being required.
 
 <environmentVariables>
@@ -204,19 +204,18 @@ These are the things you can return:
   EnvironmentVariableName = "EnvironmentVariableValue";
 
 <extraWrapperArgs>
-  a flexible set of categories, each containing a list of 
-  extra wrapper arguments.
+  a flexible set of categories, each containing extra wrapper arguments.
   If you don't know what that is, see here:
 github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
 
 <extraLuaPackages>
-  a flexible set of categories, each containing a list of FUNCTIONS 
+  a flexible set of categories, each containing FUNCTIONS 
   that return lists of extra Lua packages.
   These functions are the same thing that you would pass to lua.withPackages.
 
 <extraPythonPackages> <extraPython3Packages> 
   TWO flexible sets of categories, one for python and the other for python3,
-  each containing a list of FUNCTIONS that return lists of python packages.
+  each containing FUNCTIONS that return lists of python packages.
   These functions are the same thing that you would pass to python.withPackages.
 
   <optionalLuaAdditions>* It can also take a lua string that can be run.
@@ -227,12 +226,103 @@ github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper
     Therefore, I have included this option.
 }
 
-how this function actually works is covered in 
+how this function actually works is covered in more depth in
 :help `nixCats.flake.nixperts.nvimBuilder`
 In essence, the contents of each set listed here are filtered
 based on the packageDefinitions set you provide, 
 where by including categoryname = true; you enable that category.
 :help `nixCats.flake.outputs.packageDefinitions`
+
+It does this recursively.
+                            *nixCats.flake.outputs.categoryDefinitions.scheme*
+
+If, inside one of these main sets, you had another set,
+it would consider that a subcategory, and you could enable it
+just like you do with a normal category, by setting a value with the
+corresponding attribute path to true in the category
+set of `nixCats.flake.outputs.packageDefinitions`.
+You can nest them as much as you like, or just have a category that is a
+single derivation.
+
+There is a behavior to keep in mind.
+
+If in your categoryDefinitions you had the following:
+>nix
+    environmentVariables = {
+      test = {
+        subtest1 = {
+          CATTESTVAR = "It worked!";
+        };
+        subtest2 = {
+          CATTESTVAR3 = "It didn't work!";
+        };
+      };
+    };
+    extraWrapperArgs = {
+      test = [
+        '' --set CATTESTVAR2 "It worked again!"''
+      ];
+    };
+<
+And in your packageDefinitions set, under categories, you had the following:
+>nix
+    test = {
+      subtest1 = true;
+    };
+<
+you could echo $CATTESTVAR and $CATTESTVAR2 in your terminal to see them.
+However you could not echo $CATTESTVAR3.
+
+All items that are not attributes of the parent set will be included
+when you enable a subcategory. This includes lists, strings, functions, etc...
+
+However, attributes will not and you must explicitly enable all attributes of
+a subcategory if you set even 1 explicitly.
+
+Thus to include CATTESTVAR3, you would have to enable it like so: >nix
+    test = {
+      subtest1 = true;
+      subtest2 = true;
+    };
+< However, those are all the items in the test category.
+So instead we can do this to enable all the subcategories in test. >nix
+    test = true;
+<
+This applies in many situations. Take this one for example.
+>nix
+    lspsAndRuntimeDeps = {
+      neonixdev = {
+        inherit (pkgs)
+<          nix-doc nil lua-language-server nixd; >nix
+      };
+    };
+    startupPlugins = {
+      neonixdev = with pkgs.vimPlugins; [
+        neodev-nvim
+        neoconf-nvim
+      ];
+    };
+
+< If you were to put the following in your packageDefinitions: >nix
+    neonixdev.nix-doc = true;
+
+< neodev-nvim and neoconf-nvim would still be included.
+ However, nil, lua-language-server, and nixd would not be!
+ You would need to pick which of those you wanted separately.
+ Sometimes this is the desired behavior.
+ Sometimes it is not and a list of packages would be better suited.
+
+ You may also use the packageDef variable within categoryDefinitions
+ to get access to the set of categories and settings that are being
+ used to define the current package being built!
+>nix
+    themer = with pkgs.vimPlugins;
+      (builtins.getAttr packageDef.categories.colorscheme {
+          # Theme switcher without creating a new category
+          "onedark" = onedark-vim;
+          "catppuccin" = catppuccin-nvim;
+        }
+      );
 
 ---------------------------------------------------------------------------------------
 Settings Profiles:                             *nixCats.flake.outputs.settings*
@@ -332,6 +422,9 @@ You can require('nixCats') for the set you define here in your lua
 It returns a lua table of the same format.
 
 see :help `nixCats`
+
+For more nuances on enabling categories and subcategories, see above at
+:help `nixCats.flake.outputs.categoryDefinitions.scheme`
 
 ---------------------------------------------------------------------------------------
 Flake Exports and Export options               *nixCats.flake.outputs.exports*
@@ -465,7 +558,8 @@ In addition to those, there is also 5 convenience functions:
 
 <mergeCatDefs> oldCats: newCats:
 for merging category definitions,
-will recursively update up to the first thing not an attrset
+will recursively update up to the first thing not an attrset.
+For our purposes, we do not consider derivations to be attrsets.
 
 <mergeOverlayLists> oldOverlist: newOverlist: self: super: let
 for merging lists of overlays like those in otherOverlays in a way 

--- a/nix/nixCatsHelp/nvimBuilder.txt
+++ b/nix/nixCatsHelp/nvimBuilder.txt
@@ -27,15 +27,11 @@ and update default values with the new ones.
           environmentVariables = {};
           extraWrapperArgs = {};
 
-          # these ones take sets of lists of FUNCTIONS,
+          # these ones take FUNCTIONS,
           # and those functions return lists of packages.
           # i.e. (_:[]) as a default argument
-          # so now you can put categories of lists of them in
+          # so now you can put categories of them in
           # and they will be sorted like everything else
-          # Idk why they work that way, 
-          # but just made a function to filter them, 
-          # call them, then combine the outputs.
-          # and I pass that in instead.
           # the source says:
           /* the function you would have passed to python.withPackages */
             extraPythonPackages = {};
@@ -148,18 +144,14 @@ and update default values with the new ones.
         let &runtimepath = join(runtimepath_list, ',')
 
         set runtimepath+=${LuaConfig}/after
-
-        lua package.path = package.path .. ';${LuaConfig}/init.lua'
-        lua require('${builtins.baseNameOf LuaConfig}')
+        source ${LuaConfig}/init.lua
       '' else ''
         let runtimepath_list = split(&runtimepath, ',')
         call insert(runtimepath_list, configdir, 0)
         let &runtimepath = join(runtimepath_list, ',')
 
         execute "set runtimepath+=" . configdir . "/after"
-
-        lua package.path = package.path .. ';' .. vim.api.nvim_get_var('configdir') .. '/init.lua'
-        lua require('${configDir}')
+        execute "source " . configdir . "/init.lua"
       '') + ''
         lua << EOF
         ${optionalLuaAdditions}
@@ -198,9 +190,9 @@ and update default values with the new ones.
 ---------------------------------------------------------------------------------
                            *nixCats.flake.nixperts.nvimBuilder.mapWrapArgCats*
 
-    # This one filters and flattens like above but for attrs of attrs 
-    # and then maps name and value
-    # into a list based on the function we provide it.
+    # This one filters and flattens like above
+    # but for if you need to map over the names and values of the
+    # innermost attribute sets, based on the function we provide it.
     # its like a flatmap function but with a built in filter for category.
     # you may use this to create entirely new 
     # categories in the builder for wrapper arguments
@@ -209,17 +201,15 @@ and update default values with the new ones.
     filterAndFlattenWrapAttrs = (import ../utils)
           .filterAndFlattenMapInnerAttrs categories;
 <
-    # This one filters and flattens attrs of lists and then maps value
-    # into a list based on the function we provide it.
-    # it the same as above but for a mapping function with 1 argument
-    # because the inner thing we are mapping is a list not a set.
+    # This one filters and flattens to a list like the first,
+    # but it also maps the result based on a function we give it.
 >nix
     filterAndFlattenWrapLists = (import ../utils)
           .filterAndFlattenMapInner categories;
 <
-    # Each of these 2 functions actually take 4 arguments. But actually,
-    # they are 4 separate functions inside one another.
-    # therefore we can supply it with the first 2 arguments, then supply it
+    # Each of these 2 functions actually take 3 arguments. But actually,
+    # they are 3 separate functions inside one another.
+    # therefore we can supply it with the first argument, then supply it
     # with a function to map, then later supply it with the final argument.
     # currently, it now works very much like a regular flatmap function.
     # it now takes a function, and a set of categories of stuff.

--- a/nix/nixCatsHelp/nvimBuilder.txt
+++ b/nix/nixCatsHelp/nvimBuilder.txt
@@ -182,15 +182,15 @@ and update default values with the new ones.
     # It includes categories marked as true, then flattens to a single list.
 >nix
     filterAndFlatten = (import ../utils)
-          .filterAndFlattenAttrsOfLists pkgs categories;
+          .filterAndFlatten categories;
 <
     # We can use that function to filter many of the options.
     # anything that has an argument in the wrapper and 
     # is a list of categories of packages, you can filter this way
 >nix
-    buildInputs = [ pkgs.stdenv.cc.cc.lib ] ++ filterAndFlatten propagatedBuildInputs;
-    start = [ nixCats ] ++ filterAndFlatten startupPlugins;
-    opt = filterAndFlatten optionalPlugins;
+    buildInputs = [ pkgs.stdenv.cc.cc.lib ] ++ pkgs.lib.unique (filterAndFlatten propagatedBuildInputs);
+    start = [ nixCats ] ++ pkgs.lib.unique (filterAndFlatten startupPlugins);
+    opt = pkgs.lib.unique (filterAndFlatten optionalPlugins);
 
     # I didnt add stdenv.cc.cc.lib, so I would suggest not removing it.
     # It has cmake in it among other things.
@@ -207,7 +207,7 @@ and update default values with the new ones.
     # more info on wrapper arguments below.
 >nix
     filterAndFlattenWrapAttrs = (import ../utils)
-          .FilterAttrsOfAttrsFlatMapInner pkgs categories;
+          .filterAndFlattenMapInnerAttrs categories;
 <
     # This one filters and flattens attrs of lists and then maps value
     # into a list based on the function we provide it.
@@ -215,7 +215,7 @@ and update default values with the new ones.
     # because the inner thing we are mapping is a list not a set.
 >nix
     filterAndFlattenWrapLists = (import ../utils)
-          .FilterAttrsOfListsFlatMapInner pkgs categories;
+          .filterAndFlattenMapInner categories;
 <
     # Each of these 2 functions actually take 4 arguments. But actually,
     # they are 4 separate functions inside one another.
@@ -268,9 +268,9 @@ and update default values with the new ones.
       # this sets the name of the folder to look for nvim stuff in
       (if configDir != "nvim" then [ ''--set NVIM_APPNAME "${configDir}"'' ] else [])
       # and these are our now sorted args
-      ++ (FandF_WrapRuntimeDeps lspsAndRuntimeDeps)
-      ++ (FandF_envVarSet environmentVariables)
-      ++ (FandF_passWrapperArgs extraWrapperArgs)
+      ++ (pkgs.lib.unique (FandF_WrapRuntimeDeps lspsAndRuntimeDeps))
+      ++ (pkgs.lib.unique (FandF_envVarSet environmentVariables))
+      ++ (pkgs.lib.unique (FandF_passWrapperArgs extraWrapperArgs))
     );
 <
 ---------------------------------------------------------------------------------

--- a/nix/nixCatsHelp/tags
+++ b/nix/nixCatsHelp/tags
@@ -13,6 +13,7 @@ nixCats.flake.nixperts.overlays	overlays.txt	/*nixCats.flake.nixperts.overlays*
 nixCats.flake.outputs	nixCatsFlake.txt	/*nixCats.flake.outputs*
 nixCats.flake.outputs.builder	nixCatsFlake.txt	/*nixCats.flake.outputs.builder*
 nixCats.flake.outputs.categories	nixCatsFlake.txt	/*nixCats.flake.outputs.categories*
+nixCats.flake.outputs.categoryDefinitions.scheme	nixCatsFlake.txt	/*nixCats.flake.outputs.categoryDefinitions.scheme*
 nixCats.flake.outputs.exports	nixCatsFlake.txt	/*nixCats.flake.outputs.exports*
 nixCats.flake.outputs.exports.mkHomeModules	nixCatsFlake.txt	/*nixCats.flake.outputs.exports.mkHomeModules*
 nixCats.flake.outputs.exports.mkNixosModules	nixCatsFlake.txt	/*nixCats.flake.outputs.exports.mkNixosModules*

--- a/nix/templates/fresh/flake.nix
+++ b/nix/templates/fresh/flake.nix
@@ -92,11 +92,13 @@
         categoryDefinitions packageDefinitions;
 
       # see :help nixCats.flake.outputs.categories
+      # and
+      # :help nixCats.flake.outputs.categoryDefinitions.scheme
       categoryDefinitions = packageDef: {
         # The top level sets are not arbitrary,
         # they define what you can provide categories of.
         # However, the categories within very much are arbitrary.
-        # simply add a new list to a set here,
+        # simply add a new list, set or item to a set here,
         # and later, you will include categoryname = true; in the set you
         # provide when you build the package using this builder function.
         # see :help nixCats.flake.outputs.packageDefinitions for info on that section.
@@ -112,11 +114,6 @@
         # However, they WILL be available to the shell 
         # and neovim path when using nix develop
         propagatedBuildInputs = {
-          # remember these categories are arbitrary
-          # we will include them by name per package as desired
-          # make as many lists as you want to.
-          general = with pkgs; [
-          ];
         };
 
         # lspsAndRuntimeDeps:
@@ -124,35 +121,10 @@
         # at RUN TIME for plugins. Will be available to PATH within neovim terminal
         # this includes LSPs
         lspsAndRuntimeDeps = {
-          general = with pkgs; [
-          ];
         };
 
         # This is for plugins that will load at startup without using packadd:
         startupPlugins = {
-          general = with pkgs.vimPlugins; [
-          ];
-          # themer = with pkgs.vimPlugins; [
-          #   # You can retreive information from the
-          #   # packageDefinitions of the package this was packaged with.
-          #   # you can use it to create something like subcategories
-          #   # that could still be set by customPackager
-          #   (builtins.getAttr packageDef.categories.colorscheme {
-          #       # Theme switcher without creating a new category
-          #       "onedark" = onedark-vim;
-          #       "catppuccin" = catppuccin-nvim;
-          #       "catppuccin-mocha" = catppuccin-nvim;
-          #       "tokyonight" = tokyonight-nvim;
-          #       "tokyonight-day" = tokyonight-nvim;
-          #     }
-          #   )
-          #   # This is obviously a fairly basic usecase for this, but still nice.
-          #   # Better would be something like:
-          #   # language specific packaging that still keeps debuggers in the debugger category
-          #
-          #   # Checking packageDefinitions also has the bonus
-          #   # of being able to be easily set by importing flakes.
-          # ];
         };
 
         # not loaded automatically at startup.
@@ -164,28 +136,21 @@
         # this section is for environmentVariables that should be available
         # at RUN TIME for plugins. Will be available to path within neovim terminal
         environmentVariables = {
-          test = {
-            CATTESTVAR = "It worked!";
-          };
         };
 
         # If you know what these are, you can provide custom ones by category here.
         # If you dont, check this link out:
         # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
         extraWrapperArgs = {
-          test = [
-            '' --set CATTESTVAR2 "It worked again!"''
-          ];
         };
 
+        # lists of the functions you would have passed to
+        # python.withPackages or lua.withPackages
         extraPythonPackages = {
-          test = [ (_:[]) ];
         };
         extraPython3Packages = {
-          test = [ (_:[]) ];
         };
         extraLuaPackages = {
-          test = [ (_:[]) ];
         };
       };
 
@@ -225,9 +190,6 @@
           # and a set of categories that you want
           # (and other information to pass to lua)
           categories = {
-            general = true;
-            # themer = true;
-            # colorscheme = onedark;
             test = true;
             example = {
               youCan = "add more than just booleans";
@@ -245,10 +207,6 @@
         regularCats = { 
           settings = settings.unwrappedLua;
           categories = {
-            # themer = true;
-            # colorscheme = catppuccin;
-            general = true;
-            test = true;
           };
         };
       };

--- a/nix/templates/touchUpExisting/flake.nix
+++ b/nix/templates/touchUpExisting/flake.nix
@@ -86,6 +86,8 @@
         categoryDefinitions packageDefinitions;
 
       # see :help nixCats.flake.outputs.categories
+      # and
+      # :help nixCats.flake.outputs.categoryDefinitions.scheme
       categoryDefinitions = utils.mergeCatDefs
         nixCats.categoryDefinitions.${system} (packageDef: {
         # You may use packageDef to further

--- a/nix/templates/touchUpExisting/flake.nix
+++ b/nix/templates/touchUpExisting/flake.nix
@@ -86,7 +86,7 @@
         categoryDefinitions packageDefinitions;
 
       # see :help nixCats.flake.outputs.categories
-      categoryDefinitions = utils.mergeCatDefs pkgs 
+      categoryDefinitions = utils.mergeCatDefs
         nixCats.categoryDefinitions.${system} (packageDef: {
         # You may use packageDef to further
         # customize the contents of the set returned here per package,

--- a/nix/utils/homeManagerModule.nix
+++ b/nix/utils/homeManagerModule.nix
@@ -147,7 +147,7 @@
       then options_set.categoryDefinitions.replace
       else (
         if options_set.categoryDefinitions.merge != null then
-        (utils.mergeCatDefs newPkgs categoryDefinitions options_set.categoryDefinitions.merge)
+        (utils.mergeCatDefs categoryDefinitions options_set.categoryDefinitions.merge)
         else categoryDefinitions
       );
     newSystemPackageDefinition = {

--- a/nix/utils/nixosModule.nix
+++ b/nix/utils/nixosModule.nix
@@ -264,7 +264,7 @@
         then user_options_set.categoryDefinitions.replace
         else (
           if user_options_set.categoryDefinitions.merge != null then
-          (utils.mergeCatDefs newPkgs categoryDefinitions user_options_set.categoryDefinitions.merge)
+          (utils.mergeCatDefs categoryDefinitions user_options_set.categoryDefinitions.merge)
           else categoryDefinitions
         );
       newUserPackageDefinition = {
@@ -308,7 +308,7 @@
       then options_set.categoryDefinitions.replace
       else (
         if options_set.categoryDefinitions.merge != null then
-        (utils.mergeCatDefs newPkgs categoryDefinitions options_set.categoryDefinitions.merge)
+        (utils.mergeCatDefs categoryDefinitions options_set.categoryDefinitions.merge)
         else categoryDefinitions
       );
     newSystemPackageDefinition = {


### PR DESCRIPTION
NESTED CATEGORIES!!! Categories on categories on categories, but everything from before still works exactly the same.

Fixed bug with nixCats where it would choke on table names not valid by default in lua

Fixed bug with loading that caused it to run init.lua 3 times.

Only 1, tiny, breaking change. If you have made use of utils.mergeCatDefs, which honestly, I would be surprised if you had, you will need to delete the first argument, pkgs, as it is no longer required.