### PR TITLE
added support for home manager module syntax for plugins

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718149104,
-        "narHash": "sha256-Ds1QpobBX2yoUDx9ZruqVGJ/uQPgcXoYuobBguyKEh8=",
+        "lastModified": 1718470082,
+        "narHash": "sha256-u2F0MMYE+Efc+ocruTbtU/wWHuYHWcJafp5zJ++n/YE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e913ae340076bbb73d9f4d3d065c2bca7caafb16",
+        "rev": "3027ba73dfef68eb555fc2fa97aed4e999e74f97",
         "type": "github"
       },
       "original": {
@@ -32,27 +32,10 @@
         "type": "github"
       }
     },
-    "plugins-nvim-nio": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1717951894,
-        "narHash": "sha256-gAbqGPNBYkj+x+wR6WN2x7kqKaxlBzVXPmRXm8sM40Y=",
-        "owner": "nvim-neotest",
-        "repo": "nvim-nio",
-        "rev": "7969e0a8ffabdf210edd7978ec954a47a737bbcc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nvim-neotest",
-        "repo": "nvim-nio",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "plugins-hlargs": "plugins-hlargs",
-        "plugins-nvim-nio": "plugins-nvim-nio"
+        "plugins-hlargs": "plugins-hlargs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,6 @@
       url = "github:m-demare/hlargs.nvim";
       flake = false;
     };
-    "plugins-nvim-nio" = {
-      url = "github:nvim-neotest/nvim-nio";
-      flake = false;
-    };
 
     # neovim-nightly-overlay = {
     #   url = "github:nix-community/neovim-nightly-overlay";
@@ -118,7 +114,7 @@
       # This is for plugins that will load at startup without using packadd:
       startupPlugins = {
         debug = with pkgs.vimPlugins; [
-          pkgs.neovimPlugins.nvim-nio
+          nvim-nio
           nvim-dap
           nvim-dap-ui
           nvim-dap-virtual-text

--- a/nix/builder/default.nix
+++ b/nix/builder/default.nix
@@ -60,7 +60,7 @@ let
   # the source says:
     /* the function you would have passed to python.withPackages */
   # So you put in a set of categories of lists of them.
-    extraPythonPackages = {};
+    # extraPythonPackages = {};
     extraPython3Packages = {};
     extraPython3wrapperArgs = {};
   # same thing except for lua.withPackages
@@ -275,7 +275,7 @@ in
     };
   };
     /* the function you would have passed to python.withPackages */
-  extraPythonPackages = combineCatsOfFuncs extraPythonPackages;
+  # extraPythonPackages = combineCatsOfFuncs extraPythonPackages;
     /* the function you would have passed to python.withPackages */
   withPython3 = settings.withPython3;
   extraPython3Packages = combineCatsOfFuncs extraPython3Packages;

--- a/nix/nixCatsHelp/nixCatsFlake.txt
+++ b/nix/nixCatsHelp/nixCatsFlake.txt
@@ -349,7 +349,16 @@ This applies in many situations. Take this one for example.
   instead be defined within an attribute set that also contains config
   to be ran before sourcing init.lua (nixCats, however is still accessible)
   to do this, you may use the following syntax in opt or start sections: >nix
-    { plugin = derivation; config.vim = ""; config.lua = ""; }
+    [
+      # you may add a plugin to a category list in any of these ways
+      { plugin = derivation; config.vim = ""; config.lua = ""; }
+      { plugin = derivation; config = ""; type = "<viml or lua>"; }
+      { plugin = derivation; config = ""; } # defaults to viml
+      { plugin = derivation; }
+      # all the above options can accept an optional = bool;
+      # to override its presence in either startupPlugins or optionalPlugins
+      derivation
+    ]
 <
 ---------------------------------------------------------------------------------------
 Package Generation:                           *nixCats.flake.outputs.packageDefinitions*


### PR DESCRIPTION
```nix
    with pkgs.vimPlugins; [
      derivation
      # you may add a plugin to a category list in any of these ways
      # all the following options can accept an optional = bool;
      # to override its presence in either startupPlugins or optionalPlugins
      { plugin = derivation; config.vim = ""; config.lua = ""; }
      { plugin = derivation; config = ""; type = "<viml or lua>"; }
      { plugin = derivation; config = ""; } # defaults to viml
      { plugin = derivation; }
    ]
```