### PR TITLE
setting addition

### DIFF
--- a/nix/builder/default.nix
+++ b/nix/builder/default.nix
@@ -85,7 +85,7 @@ let
     extraName = "";
     withPython3 = true;
     configDirName = "nvim";
-    unwrappedFakeXDGcfg = null;
+    unwrappedCfgPath = null;
     aliases = null;
     nvimSRC = null;
     neovim-unwrapped = null;
@@ -149,10 +149,8 @@ in
       execute "set runtimepath-=" . configdir . "/after"
     '') + (if settings.wrapRc then /* vim */''
       let configdir = "${LuaConfig}"
-    '' else if settings.unwrappedFakeXDGcfg != null
-         && settings.configDirName != null
-      then /* vim */''
-      let configdir = "${settings.unwrappedFakeXDGcfg}/${settings.configDirName}"
+    '' else if settings.unwrappedCfgPath != null then /* vim */''
+      let configdir = "${settings.unwrappedCfgPath}"
     '' else "") + /* vim */ ''
       lua require('nixCats').addGlobals()
       lua require('nixCats.saveTheCats')

--- a/nix/builder/default.nix
+++ b/nix/builder/default.nix
@@ -57,10 +57,7 @@ let
     propagatedBuildInputs = {};
     environmentVariables = {};
     extraWrapperArgs = {};
-  # the source says:
     /* the function you would have passed to python.withPackages */
-  # So you put in a set of categories of lists of them.
-    # extraPythonPackages = {};
     extraPython3Packages = {};
     extraPython3wrapperArgs = {};
   # same thing except for lua.withPackages
@@ -88,6 +85,7 @@ let
     extraName = "";
     withPython3 = true;
     configDirName = "nvim";
+    unwrappedFakeXDGcfg = null;
     aliases = null;
     nvimSRC = null;
     neovim-unwrapped = null;
@@ -151,6 +149,10 @@ in
       execute "set runtimepath-=" . configdir . "/after"
     '') + (if settings.wrapRc then /* vim */''
       let configdir = "${LuaConfig}"
+    '' else if settings.unwrappedFakeXDGcfg != null
+         && settings.configDirName != null
+      then /* vim */''
+      let configdir = "${settings.unwrappedFakeXDGcfg}/${settings.configDirName}"
     '' else "") + /* vim */ ''
       lua require('nixCats').addGlobals()
       lua require('nixCats.saveTheCats')

--- a/nix/nixCatsHelp/nixCatsFlake.txt
+++ b/nix/nixCatsHelp/nixCatsFlake.txt
@@ -457,6 +457,12 @@ These are the defaults:
       # see :help `$NVIM_APPNAME`
       configDirName = "nvim";
 
+      # Only active when wrapRc = false, this option allows you to specify
+      # an absolute path to the unwrapped config directory.
+      # Will not change anything other than config directory, configDirName
+      # is still needed for .local/share or .cache and the like
+      unwrappedCfgPath = null;
+
       # These 2 options are useful for when you want to allow your dev shells
       # to override things such as lsps and shared libraries that you have
       # already in your configuration.


### PR DESCRIPTION
Allows you to specify the absolute path to the config dir when wrapRc is false, instead of only being able to use NVIM_APPNAME via configDirName setting. Will override config path set by NVIM_APPNAME but will not override for any other directories.