### PR TITLE
non-breaking: makeOverlay utilities now can optionally accept keepLuaBuilder instead of luaPath

### DIFF
--- a/lua/myLuaConf/plugins/init.lua
+++ b/lua/myLuaConf/plugins/init.lua
@@ -167,7 +167,6 @@ vim.keymap.set("n", "-", "<cmd>Oil<CR>", { noremap = true, desc = 'Open Parent D
 vim.keymap.set("n", "<leader>-", "<cmd>Oil .<CR>", { noremap = true, desc = 'Open nvim root directory' })
 
 require('which-key').setup({
-  operators = { gc = "Comments", [ "<leader>y" ] = "yank to clipboard", },
 })
 require('which-key').add {
     { "<leader><leader>", group = "buffer commands" },

--- a/nix/builder/wrapper.nix
+++ b/nix/builder/wrapper.nix
@@ -179,8 +179,6 @@ let
       (builtins.concatStringsSep "\n" (builtins.map (alias: ''
         ln -s $out/bin/${nixCats_packageName} $out/bin/${alias}
       '') customAliases))
-
-      # more stuff from nixpkgs. I still dont entirely understand the rplugin manifest generation.
       + lib.optionalString (manifestRc != null) (let
         manifestWrapperArgs =
           [ "${neovim-unwrapped}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ] ++ finalAttrs.generatedWrapperArgs;
@@ -214,7 +212,7 @@ let
           exit 1
         fi
         rm "${placeholder "out"}/bin/nvim-wrapper"
-        # ok, again, I dont entirely understand the above part, if anyone knows, let me know.
+        # I only mostly understand the above 10 lines. They are from nixpkgs.
       '')
 
       + /* bash */ ''

--- a/nix/utils/default.nix
+++ b/nix/utils/default.nix
@@ -48,8 +48,9 @@ with builtins; rec {
       }@pkgsParams:
       categoryDefFunction:
       packageDefinitions: defaultName: let
+        keepLuaBuilder = if builtins.isFunction luaPath then luaPath else utils.baseBuilder luaPath;
         makeOverlay = name: final: prev: {
-          ${name} = utils.baseBuilder luaPath (pkgsParams // { inherit (final) system; }) categoryDefFunction packageDefinitions name;
+          ${name} = keepLuaBuilder (pkgsParams // { inherit (final) system; }) categoryDefFunction packageDefinitions name;
         };
         overlays = (mapAttrs (name: _: makeOverlay name) packageDefinitions) // { default = (makeOverlay defaultName); };
       in overlays;
@@ -72,10 +73,12 @@ with builtins; rec {
       (self: super: {
         ${importName} = listToAttrs (
           map
-            (name:
+            (name: let
+              keepLuaBuilder = if builtins.isFunction luaPath then luaPath else utils.baseBuilder luaPath;
+            in
               {
                 inherit name;
-                value =  utils.baseBuilder luaPath (pkgsParams // { inherit (final) system; }) categoryDefFunction packageDefinitions name;
+                value =  keepLuaBuilder (pkgsParams // { inherit (final) system; }) categoryDefFunction packageDefinitions name;
               }
             ) namesIncList
           );


### PR DESCRIPTION
allowed makeOverlay utilites to accept a keepLuaBuilder (a builder that already has been given a luaPath argument), removed a deprecated which-key option from the example config