### PR TITLE
Fix for mac (and gnu?) tail

### DIFF
--- a/nix/builder/wrapper.nix
+++ b/nix/builder/wrapper.nix
@@ -243,7 +243,7 @@ let
         # add the code to set the environment variable
         cat ${preWrapperShellFile} >> $BASHCACHE
         # add the rest of the file back
-        tail +2 ${placeholder "out"}/bin/${nixCats_packageName} >> $BASHCACHE
+        tail -n +2 ${placeholder "out"}/bin/${nixCats_packageName} >> $BASHCACHE
         cat $BASHCACHE > ${placeholder "out"}/bin/${nixCats_packageName}
         rm $BASHCACHE
       '';


### PR DESCRIPTION
I don‘t know which tail nixos uses but on mac (and also on [ubuntu](https://stackoverflow.com/questions/44054761/tail-cannot-open-2-for-reading-no-such-file-or-directory)?) you have to specify the `tail` with the `-n` flag, otherwise you get the following error:

```bash
> tail: cannot open '+2' for reading: No such file or directory
> /nix/store/89ghmy7qxyggz4sycc9qr1klinmrlgbx-stdenv-darwin/setup: line 202: pop_var_context: head of shell_variables not a function context
```