### PR TITLE
Added a minimal internal flake that doesnt need nixpkgs input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
 
   # see :help nixCats.flake.outputs
   outputs = { self, nixpkgs, ... }@inputs: let
-    utils = (import ./nix/utils).utils;
+    utils = import ./nix;
     luaPath = "${./.}";
     # this is flake-utils eachSystem
     forEachSystem = utils.eachSystem nixpkgs.lib.platforms.all;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,1 @@
+(import ./utils).utils

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = ''
+    This flake can be imported with the flake reference
+
+    inputs.nixCats.url = "github:BirdeeHub/nixCats-nvim?dir=nix";
+
+    inputs.nixCats.url = "github:BirdeeHub/nixCats-nvim/<ref_or_rev>?dir=nix";
+
+    If you want to drop even the nixpkgs dependency of nixCats,
+    you may import this instead.
+
+    It does not export modules or packages because those need nixpkgs.
+
+    However, it exports everything required for the default template,
+    and the nixExpressionFlakeOutputs template.
+    Which will still be able to output everything,
+    including its own modules, overlays and packages.
+
+    If you import the module straight from nixCats,
+    or use override directly on a nixCats package,
+    this minimal version will not work, but everything
+    required to build a package is still exported
+    via this set.
+  '';
+  outputs = inputs: let
+    utils = import ./.;
+  in {
+    # everything is in utils.
+    inherit utils;
+    inherit (utils) templates;
+  };
+}

--- a/nix/templates/fresh/flake.nix
+++ b/nix/templates/fresh/flake.nix
@@ -22,8 +22,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixCats.url = "github:BirdeeHub/nixCats-nvim";
-    nixCats.inputs.nixpkgs.follows = "nixpkgs";
+    nixCats.url = "github:BirdeeHub/nixCats-nvim?dir=nix";
 
     # neovim-nightly-overlay = {
     #   url = "github:nix-community/neovim-nightly-overlay";

--- a/nix/templates/kickstart-nvim/flake.nix
+++ b/nix/templates/kickstart-nvim/flake.nix
@@ -22,8 +22,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixCats.url = "github:BirdeeHub/nixCats-nvim";
-    nixCats.inputs.nixpkgs.follows = "nixpkgs";
+    nixCats.url = "github:BirdeeHub/nixCats-nvim?dir=nix";
 
     # neovim-nightly-overlay = {
     #   url = "github:nix-community/neovim-nightly-overlay";

--- a/nix/templates/nixExpressionFlakeOutputs/default.nix
+++ b/nix/templates/nixExpressionFlakeOutputs/default.nix
@@ -5,8 +5,7 @@
   # (lazy.nvim wrapper only works on unstable)
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixCats.url = "github:BirdeeHub/nixCats-nvim";
-    nixCats.inputs.nixpkgs.follows = "nixpkgs";
+    nixCats.url = "github:BirdeeHub/nixCats-nvim?dir=nix";
   };
 
   Then call this file with:
@@ -20,7 +19,7 @@
   The following is just the outputs function from the flake template.
  */
 {inputs, ... }@attrs: let
-  inherit (inputs) nixpkgs;
+  inherit (inputs) nixpkgs; # <-- nixpkgs = inputs.nixpkgsSomething;
   inherit (inputs.nixCats) utils;
   luaPath = "${./.}";
   forEachSystem = utils.eachSystem nixpkgs.lib.platforms.all;
@@ -38,11 +37,10 @@
     # `plugins-<pluginName>`
     # Once we add this overlay to our nixpkgs, we are able to
     # use `pkgs.neovimPlugins`, which is a set of our plugins.
-    dependencyOverlays = [ (utils.mergeOverlayLists inputs.nixCats.dependencyOverlays.${system}
-    ((import ./overlays inputs) ++ [
+    dependencyOverlays = (import ./overlays inputs) ++ [
       (utils.standardPluginOverlay inputs)
       # add any flake overlays here.
-    ])) ];
+    ];
   in { inherit dependencyOverlays; })) dependencyOverlays;
 
   categoryDefinitions = { pkgs, settings, categories, name, ... }@packageDef: {


### PR DESCRIPTION
Everything to build either of the starter templates is exported via the utils set, which requires no dependencies to import.

So I have optionally included a second flake that can be used instead that only exports the utils set and templates.

If you are importing the modules directly from nixCats, or overriding a nixCats package directly, that will continue to work still via importing the main flake as before, and will continue to work.

But for those who listened to the advice of using either of the starter templates, `default` or `nixExpressionFlakeOutputs`, and then using modules and override for modifying your _own_ existing config, all of which only requires the utils set, heres a minimal version you can use if you wish.