### PR TITLE
minor deprecations due for 2024-09-01

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -452,20 +452,6 @@
     };
     inherit utils;
     inherit (utils) templates;
-
-    # override feature makes these following outputs unnecessary,
-    # and I would be surprised if someone was merging categoryDefinitions or packageDefinitions
-    # from the example config into their own. The example config does a good job with lsps
-    # but a bad job with lazy loading for simplicities sake,
-    # only lazy loading 1 plugin for demonstration purposes.
-    # In addition to them being available in override, you can still get them via passthru
-    inherit categoryDefinitions packageDefinitions;
-    inherit (utils) baseBuilder;
-    keepLuaBuilder = utils.baseBuilder luaPath;
-    inherit dependencyOverlays;
-    # But in case people were using them, we will still export them for now.
-    # Will be removed along with the old mkOverlays functions on 2024-09-01
-    # and were already removed from the templates
   };
 
 }

--- a/lua/nixCatsUtils/init.lua
+++ b/lua/nixCatsUtils/init.lua
@@ -12,16 +12,38 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---defaults to true if non_nix_value is not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
-    if not M.isNixCats then
-        local nixCats_default_value
-        if type(v) == "table" and type(v.non_nix_value) == "boolean" then
-            nixCats_default_value = v.non_nix_value
-        else
-            nixCats_default_value = true
-        end
-        -- if not in nix, just make it return a boolean
-        require('_G').nixCats = function(_) return nixCats_default_value end
+  if not M.isNixCats then
+    local nixCats_default_value
+    if type(v) == "table" and type(v.non_nix_value) == "boolean" then
+      nixCats_default_value = v.non_nix_value
+    else
+      nixCats_default_value = true
     end
+    -- if not in nix, just make it return a boolean
+    require('_G').nixCats = function(_) return nixCats_default_value end
+    -- and define some stuff for the nixCats plugin
+    -- to prevent indexing errors and provide some values
+    package.preload['nixCats'] = function ()
+      return {
+        cats = {},
+        pawsible = {
+          allPlugins = {
+            start = {},
+            opt = {},
+            treesitter_grammars = {},
+            ts_grammar_path = nil,
+          },
+        },
+        settings = {
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        },
+        configDir = vim.fn.stdpath('config'),
+        packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
+      }
+    end
+  end
 end
 
 ---allows you to guarantee a boolean is returned, and also declare a different

--- a/lua/nixCatsUtils/lazyCat.lua
+++ b/lua/nixCatsUtils/lazyCat.lua
@@ -42,13 +42,14 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     return lazypath
   end
 
-  local ok, nixCats = pcall(require,'nixCats')
+  local isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
   local lazypath
-  if not ok then
+  if not isNixCats then
     -- No nixCats? Not nix. Do it normally
     lazypath = regularLazyDownload()
     vim.opt.rtp:prepend(lazypath)
   else
+    local nixCats = require('nixCats')
     -- Else, its nix, so we wrap lazy with a few extra config options
     lazypath = nixLazyPath
     -- and also we probably dont have to download lazy either
@@ -104,11 +105,11 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     }
     lazyCFG = vim.tbl_deep_extend("force", lazyCFG or {}, newLazyOpts)
     -- do the reset we disabled without removing important stuff
-    local cfgdir = require('nixCats').configDir
+    local cfgdir = nixCats.configDir
     vim.opt.rtp = {
       cfgdir,
-      require('nixCats').nixCatsPath,
-      require('nixCats').pawsible.allPlugins.ts_grammar_path,
+      nixCats.nixCatsPath,
+      nixCats.pawsible.allPlugins.ts_grammar_path,
       vim.fn.stdpath("data") .. "/site",
       lazypath,
       vim.env.VIMRUNTIME,

--- a/nix/builder/nixCats.lua
+++ b/nix/builder/nixCats.lua
@@ -8,6 +8,7 @@ M.configDir = M.settings.nixCats_config_location
 -- due to infinite recursion, so they are variables instead.
 M.nixCatsPath = require('nixCats.saveTheCats')
 M.vimPackDir = vim.g[ [[nixCats-special-rtp-entry-vimPackDir]] ]
+M.packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
 
 ---:h nixCats
 ---will return the nearest parent category value, unless the nearest
@@ -76,6 +77,9 @@ function M.addGlobals()
             elseif opts.fargs[1] == 'nixCatsPath' then
                 print(M.nixCatsPath)
                 return
+            elseif opts.fargs[1] == 'packageBinPath' then
+                print(M.packageBinPath)
+                return
             end
         elseif #opts.fargs == 2 then
             if opts.fargs[1] == 'cat' then
@@ -110,6 +114,7 @@ function M.addGlobals()
                 "vimPackDir",
                 "configDir",
                 "nixCatsPath",
+                "packageBinPath",
             }
             local matches = {}
 

--- a/nix/builder/nixCats.lua
+++ b/nix/builder/nixCats.lua
@@ -9,11 +9,6 @@ M.configDir = M.settings.nixCats_config_location
 M.nixCatsPath = require('nixCats.saveTheCats')
 M.vimPackDir = vim.g[ [[nixCats-special-rtp-entry-vimPackDir]] ]
 
-package.preload["nixCats.included"] = function()
-    vim.notify_once("require('nixCats.included') will be removed in favor of require('nixCats.pawsible') on 2024-09-01", vim.log.levels.WARN, { title = "NixCats Deprecation Warning" })
-    return require('nixCats.pawsible')
-end
-
 ---:h nixCats
 ---will return the nearest parent category value, unless the nearest
 ---parent is a table, in which case that means a different subcategory
@@ -168,18 +163,6 @@ function M.addGlobals()
         end,
     })
 
-    vim.api.nvim_create_user_command('NixCatsSettings', function ()
-        vim.notify_once("`:NixCatsSettings` will be removed in favor of `:NixCats settings` on 2024-09-01", vim.log.levels.WARN, { title = "NixCats Deprecation Warning" })
-        print(vim.inspect(require('nixCats.settings')))
-    end,
-    { desc = 'All the settings' })
-
-    vim.api.nvim_create_user_command('NixCatsPawsible', function ()
-        vim.notify_once("`:NixCatsPawsible` will be removed in favor of `:NixCats pawsible` on 2024-09-01", vim.log.levels.WARN, { title = "NixCats Deprecation Warning" })
-        print(vim.inspect(require('nixCats.pawsible')))
-    end,
-    { desc = 'All the pawsible plugins' })
-
     vim.cmd([[
         function! GetNixCat(value)
             return luaeval('require("nixCats").get("' . a:value . '")')
@@ -195,13 +178,6 @@ function M.addGlobals()
     vim.cmd([[
         function! GetAllNixCats()
             return v:lua.require('nixCats.cats')
-        endfunction
-    ]])
-
-    vim.cmd([[
-        function! GetNixIncluded()
-            lua vim.notify_once("`GetNixIncluded` will be removed in favor of `GetNixPawsible` on 2024-09-01", vim.log.levels.WARN, { title = "NixCats Deprecation Warning" })
-            return v:lua.require('nixCats.pawsible')
         endfunction
     ]])
 

--- a/nix/builder/nixCatsMeta.lua
+++ b/nix/builder/nixCatsMeta.lua
@@ -10,3 +10,4 @@ error("Cannot import a meta module")
 ---@field nixCatsPath string
 ---@field vimPackDir string
 ---@field configDir string
+---@field packageBinPath string

--- a/nix/templates/kickstart-nvim/lua/nixCatsUtils/init.lua
+++ b/nix/templates/kickstart-nvim/lua/nixCatsUtils/init.lua
@@ -12,16 +12,38 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---defaults to true if non_nix_value is not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
-    if not M.isNixCats then
-        local nixCats_default_value
-        if type(v) == "table" and type(v.non_nix_value) == "boolean" then
-            nixCats_default_value = v.non_nix_value
-        else
-            nixCats_default_value = true
-        end
-        -- if not in nix, just make it return a boolean
-        require('_G').nixCats = function(_) return nixCats_default_value end
+  if not M.isNixCats then
+    local nixCats_default_value
+    if type(v) == "table" and type(v.non_nix_value) == "boolean" then
+      nixCats_default_value = v.non_nix_value
+    else
+      nixCats_default_value = true
     end
+    -- if not in nix, just make it return a boolean
+    require('_G').nixCats = function(_) return nixCats_default_value end
+    -- and define some stuff for the nixCats plugin
+    -- to prevent indexing errors and provide some values
+    package.preload['nixCats'] = function ()
+      return {
+        cats = {},
+        pawsible = {
+          allPlugins = {
+            start = {},
+            opt = {},
+            treesitter_grammars = {},
+            ts_grammar_path = nil,
+          },
+        },
+        settings = {
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        },
+        configDir = vim.fn.stdpath('config'),
+        packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
+      }
+    end
+  end
 end
 
 ---allows you to guarantee a boolean is returned, and also declare a different

--- a/nix/templates/kickstart-nvim/lua/nixCatsUtils/lazyCat.lua
+++ b/nix/templates/kickstart-nvim/lua/nixCatsUtils/lazyCat.lua
@@ -42,13 +42,14 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     return lazypath
   end
 
-  local ok, nixCats = pcall(require,'nixCats')
+  local isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
   local lazypath
-  if not ok then
+  if not isNixCats then
     -- No nixCats? Not nix. Do it normally
     lazypath = regularLazyDownload()
     vim.opt.rtp:prepend(lazypath)
   else
+    local nixCats = require('nixCats')
     -- Else, its nix, so we wrap lazy with a few extra config options
     lazypath = nixLazyPath
     -- and also we probably dont have to download lazy either
@@ -104,11 +105,11 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     }
     lazyCFG = vim.tbl_deep_extend("force", lazyCFG or {}, newLazyOpts)
     -- do the reset we disabled without removing important stuff
-    local cfgdir = require('nixCats').configDir
+    local cfgdir = nixCats.configDir
     vim.opt.rtp = {
       cfgdir,
-      require('nixCats').nixCatsPath,
-      require('nixCats').pawsible.allPlugins.ts_grammar_path,
+      nixCats.nixCatsPath,
+      nixCats.pawsible.allPlugins.ts_grammar_path,
       vim.fn.stdpath("data") .. "/site",
       lazypath,
       vim.env.VIMRUNTIME,

--- a/nix/templates/luaUtils/lua/nixCatsUtils/init.lua
+++ b/nix/templates/luaUtils/lua/nixCatsUtils/init.lua
@@ -12,16 +12,38 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---defaults to true if non_nix_value is not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
-    if not M.isNixCats then
-        local nixCats_default_value
-        if type(v) == "table" and type(v.non_nix_value) == "boolean" then
-            nixCats_default_value = v.non_nix_value
-        else
-            nixCats_default_value = true
-        end
-        -- if not in nix, just make it return a boolean
-        require('_G').nixCats = function(_) return nixCats_default_value end
+  if not M.isNixCats then
+    local nixCats_default_value
+    if type(v) == "table" and type(v.non_nix_value) == "boolean" then
+      nixCats_default_value = v.non_nix_value
+    else
+      nixCats_default_value = true
     end
+    -- if not in nix, just make it return a boolean
+    require('_G').nixCats = function(_) return nixCats_default_value end
+    -- and define some stuff for the nixCats plugin
+    -- to prevent indexing errors and provide some values
+    package.preload['nixCats'] = function ()
+      return {
+        cats = {},
+        pawsible = {
+          allPlugins = {
+            start = {},
+            opt = {},
+            treesitter_grammars = {},
+            ts_grammar_path = nil,
+          },
+        },
+        settings = {
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        },
+        configDir = vim.fn.stdpath('config'),
+        packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
+      }
+    end
+  end
 end
 
 ---allows you to guarantee a boolean is returned, and also declare a different

--- a/nix/templates/luaUtils/lua/nixCatsUtils/lazyCat.lua
+++ b/nix/templates/luaUtils/lua/nixCatsUtils/lazyCat.lua
@@ -42,13 +42,14 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     return lazypath
   end
 
-  local ok, nixCats = pcall(require,'nixCats')
+  local isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
   local lazypath
-  if not ok then
+  if not isNixCats then
     -- No nixCats? Not nix. Do it normally
     lazypath = regularLazyDownload()
     vim.opt.rtp:prepend(lazypath)
   else
+    local nixCats = require('nixCats')
     -- Else, its nix, so we wrap lazy with a few extra config options
     lazypath = nixLazyPath
     -- and also we probably dont have to download lazy either
@@ -104,11 +105,11 @@ function M.setup(pluginTable, nixLazyPath, lazySpecs, lazyCFG)
     }
     lazyCFG = vim.tbl_deep_extend("force", lazyCFG or {}, newLazyOpts)
     -- do the reset we disabled without removing important stuff
-    local cfgdir = require('nixCats').configDir
+    local cfgdir = nixCats.configDir
     vim.opt.rtp = {
       cfgdir,
-      require('nixCats').nixCatsPath,
-      require('nixCats').pawsible.allPlugins.ts_grammar_path,
+      nixCats.nixCatsPath,
+      nixCats.pawsible.allPlugins.ts_grammar_path,
       vim.fn.stdpath("data") .. "/site",
       lazypath,
       vim.env.VIMRUNTIME,

--- a/nix/utils/default.nix
+++ b/nix/utils/default.nix
@@ -212,46 +212,6 @@ with builtins; rec {
           packageDefinitions defaultPackageName extra_pkg_config utils;
       });
 
-    # These were deprecated due to needing to be wrapped with ${system} and thus failing flake check
-    mkOverlays = finalBuilder: packageDefinitions: defaultName:
-      let
-        warn = trace "WARNING: utils.mkOverlays is deprecated. Use utils.makeOverlays instead. Will be removed on 2024-09-01.";
-      in (warn (
-          (utils.mkDefaultOverlay finalBuilder defaultName) 
-          //
-          (utils.mkExtraOverlays finalBuilder packageDefinitions)
-        )
-      );
-
-    mkDefaultOverlay = finalBuilder: defaultName:
-      let
-        warn = trace "WARNING: utils.mkDefaultOverlay is deprecated. Will be removed on 2024-09-01.";
-      in warn { default = (self: super: { ${defaultName} = finalBuilder defaultName; }); };
-
-    mkExtraOverlays = finalBuilder: packageDefinitions:
-      let
-        warn = trace "WARNING: utils.mkExtraOverlays is deprecated. Will be removed on 2024-09-01.";
-      in warn (mapAttrs (name: (self: super: { ${name} = finalBuilder name; })) packageDefinitions);
-
-    mkMultiOverlay = finalBuilder: importName: namesIncList:
-      let
-        warn = trace "WARNING: utils.mkMultiOverlay is deprecated. Use utils.makeMultiOverlay instead. Will be removed on 2024-09-01.";
-      in (warn 
-          (self: super: {
-            ${importName} = listToAttrs (
-              map
-                (name:
-                  {
-                    inherit name;
-                    value = finalBuilder name;
-                  }
-                ) namesIncList
-              );
-            }
-          )
-        );
-
-
     # flake-utils' main function, because its all I used
     # Builds a map from <attr>=value to <attr>.<system>=value for each system
     eachSystem = systems: f:
@@ -278,7 +238,8 @@ with builtins; rec {
                else [ currentSystem ]
             else []));
 
-    # in case someoneone wants flake-utils but for only 1 output.
+    # in case someoneone wants flake-utils but for only 1 output,
+    # and didnt know genAttrs is great as a bySystems
     bySystems = lib.genAttrs;
 
   };


### PR DESCRIPTION
While the old luaUtils templates should still work, you should pull a new luaUtils template by removing lua/nixCatsUtils/init.lua and lua/nixCatsUtils/lazyCat.lua and then running the following command at the root of your nvim config directory, as the new ones are better. (after this update goes live)

`nix flake init -t github:BirdeeHub/nixCats-nvim#luaUtils`