### PR TITLE
alternate cat def merge function

### DIFF
--- a/nixCatsHelp/nixCats_format.txt
+++ b/nixCatsHelp/nixCats_format.txt
@@ -887,6 +887,10 @@ For our purposes, we do not consider derivations to be attrsets.
 It takes 2 functions that return sets and returns
 a function which calls them both and merges the result as desired above.
 
+<deepmergeCats> oldCats: newCats:
+same as `utils.mergeCatDefs` except will merge duplicate
+category lists together instead of replacing them
+
 <mergeOverlayLists> oldOverlist: newOverlist: self: super:
 for merging lists of overlays together properly
 to avoid naming conflict issues.

--- a/nixCatsHelp/nixCats_modules.txt
+++ b/nixCatsHelp/nixCats_modules.txt
@@ -60,8 +60,8 @@ other than the packages themselves in config.${defaultPackageName}.out
           A list of overlays to make available to nixCats but not to your system.
           Will have access to system overlays regardless of this setting.
         '';
-        example = (literalExpression ''
-          addOverlays = [ (self: super: { neovimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+        example = (lib.literalExpression ''
+          addOverlays = [ (self: super: { vimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
         '');
       };
 
@@ -94,19 +94,25 @@ other than the packages themselves in config.${defaultPackageName}.out
       };
 
       categoryDefinitions = {
+        existing = mkOption {
+          default = "replace";
+          type = types.enum [ "replace" "merge" "discard" ];
+          description = ''
+            the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+            choose between "replace", "merge" or "discard"
+            replace uses utils.mergeCatDefs
+            merge uses utils.deepmergeCats
+            discard does not inherit
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+          '';
+        };
         replace = mkOption {
           default = null;
-          type = types.nullOr catDef;
+          type = types.nullOr (catDef "replace");
           description = (literalExpression ''
-            Takes a function that receives the package definition set of this package
-            and returns a set of categoryDefinitions,
-            just like :help nixCats.flake.outputs.categories
-            you should use ${pkgs.system} provided in the packageDef set
-            to access system specific items.
-
-            If any value is found for categoryDefinitions.replace,
-            any inherited values from the package this module was based on, if any, will be overwritten.
-            To merge with inherited values, use categoryDefinitions.merge instead, and do not set this value.
+            see :help nixCats.flake.outputs.categories
+            uses utils.mergeCatDefs to recursively update old categories with new values
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
           '');
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -115,14 +121,11 @@ other than the packages themselves in config.${defaultPackageName}.out
         };
         merge = mkOption {
           default = null;
-          type = types.nullOr catDef;
+          type = types.nullOr (catDef "merge");
           description = ''
-            Takes a function that receives the package definition set of this package
-            and returns a set of categoryDefinitions,
-            just like :help nixCats.flake.outputs.categories
-            Will merge the categoryDefinitions of the flake with this value,
-            recursively updating all non-attrset values,
-            such as replacing old category lists with ones defined here.
+            see :help nixCats.flake.outputs.categories
+            uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
           '';
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -145,7 +148,7 @@ other than the packages themselves in config.${defaultPackageName}.out
           see :help nixCats.flake.outputs.settings
           and :help nixCats.flake.outputs.categories
         '';
-        type = with types; nullOr (attrsOf catDef);
+        type = with types; nullOr (attrsOf (catDef "replace"));
         example = ''
           nixCats.packages = { 
             nixCats = { pkgs, ... }: {

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -439,16 +439,16 @@ with builtins; rec {
       name = "catDef";
       description = "a function representing categoryDefinitions or packageDefinitions for nixCats";
       descriptionClass = "noun";
-      check = v: builtins.isFunction v;
+      check = v: isFunction v;
       merge = loc: defs: let
         values = map (v: v.value) defs;
         mergefunc = if subtype == "replace"
         then lib.recursiveUpdateUntilDRV 
         else if subtype == "merge"
         then lib.recursiveUpdateWithMerge
-        else builtins.throw "invalid catDef subtype";
+        else throw "invalid catDef subtype";
       in
-      arg: builtins.foldl' mergefunc {} (map (v: v arg) values);
+      arg: foldl' mergefunc {} (map (v: v arg) values);
     };
   };
 }

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -84,21 +84,16 @@ in {
             replace uses utils.mergeCatDefs
             merge uses utils.deepmergeCats
             discard does not inherit
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
           '';
         };
         replace = mkOption {
           default = null;
           type = types.nullOr (catDef "replace");
           description = (literalExpression ''
-            Takes a function that receives the package definition set of this package
-            and returns a set of categoryDefinitions,
-            just like :help nixCats.flake.outputs.categories
-            you should use ${pkgs.system} provided in the packageDef set
-            to access system specific items.
-
-            If any value is found for categoryDefinitions.replace,
-            any inherited values from the package this module was based on, if any, will be overwritten.
-            To merge with inherited values, use categoryDefinitions.merge instead, and do not set this value.
+            see :help nixCats.flake.outputs.categories
+            uses utils.mergeCatDefs to recursively update old categories with new values
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
           '');
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -109,12 +104,9 @@ in {
           default = null;
           type = types.nullOr (catDef "merge");
           description = ''
-            Takes a function that receives the package definition set of this package
-            and returns a set of categoryDefinitions,
-            just like :help nixCats.flake.outputs.categories
-            Will merge the categoryDefinitions of the flake with this value,
-            recursively updating all non-attrset values,
-            such as replacing old category lists with ones defined here.
+            see :help nixCats.flake.outputs.categories
+            uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
           '';
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -241,21 +233,16 @@ in {
                   replace uses utils.mergeCatDefs
                   merge uses utils.deepmergeCats
                   discard does not inherit
+                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
                 '';
               };
               replace = mkOption {
                 default = null;
                 type = types.nullOr (catDef "replace");
                 description = ''
-                  Takes a function that receives the package definition set of this package
-                  and returns a set of categoryDefinitions,
-                  just like :help nixCats.flake.outputs.categories
-                  you should use ''${pkgs.system} provided in the packageDef set
-                  to access system specific items.
-
-                  If any value is found for categoryDefinitions.replace,
-                  any inherited values from the package this module was based on, if any, will be overwritten.
-                  To merge with inherited values, use categoryDefinitions.merge instead, and do not set this value.
+                  see :help nixCats.flake.outputs.categories
+                  uses utils.mergeCatDefs to recursively update old categories with new values
+                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
                 '';
                 example = ''
                   # see :help nixCats.flake.outputs.categories
@@ -266,12 +253,9 @@ in {
                 default = null;
                 type = types.nullOr (catDef "merge");
                 description = ''
-                  Takes a function that receives the package definition set of this package
-                  and returns a set of categoryDefinitions,
-                  just like :help nixCats.flake.outputs.categories
-                  Will merge the categoryDefinitions of the flake with this value,
-                  recursively updating all non-attrset values,
-                  such as replacing old category lists with ones defined here.
+                  see :help nixCats.flake.outputs.categories
+                  uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
+                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
                 '';
                 example = ''
                   # see :help nixCats.flake.outputs.categories

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -18,10 +18,6 @@
   catDef = my_lib.mkCatDefType lib.mkOptionType;
 in {
 
-  imports = [
-    (lib.mkRenamedOptionModule [ defaultPackageName "packages" ] [ defaultPackageName "packageDefinitions" ])
-  ];
-
   options = with lib; {
 
     ${defaultPackageName} = {
@@ -115,7 +111,7 @@ in {
         };
       };
 
-      packageDefinitions = mkOption {
+      packages = mkOption {
         default = null;
         description = ''
           VERY IMPORTANT when setting aliases for each package,
@@ -260,12 +256,6 @@ in {
 
             packages = mkOption {
               default = null;
-              type = with types; nullOr (attrsOf (catDef "replace"));
-              visible = false;
-              apply = builtins.trace "Obsolete option `${defaultPackageName}.users.<USER>.packages` is used. It was renamed to `${defaultPackageName}.users.<USER>.packageDefinitions`.";
-            };
-            packageDefinitions = mkOption {
-              default = null;
               description = ''
                 VERY IMPORTANT when setting aliases for each package,
                 they must not be the same as ANY other neovim package for that user.
@@ -335,11 +325,8 @@ in {
         );
       in stratWithExisting categoryDefinitions moduleCatDefs;
 
-      pkgDefs = let
-        oldtype = options_set ? packages && options_set.packages != null;
-        newtype = options_set.packageDefinitions != null;
-      in if (newtype || oldtype)
-        then packageDefinitions // (lib.optionalAttrs oldtype options_set.packages) // (lib.optionalAttrs newtype options_set.packageDefinitions) else packageDefinitions;
+      pkgDefs = if (options_set.packages != null)
+        then packageDefinitions // options_set.packages else packageDefinitions;
 
       newLuaBuilder = (if options_set.luaPath != "" then (utils.baseBuilder options_set.luaPath)
         else 


### PR DESCRIPTION
This one is capable of merging duplicate lists together. This allows for defining extensions to existing categories, rather than the only option being to completely replace with a new list

utils.deepmergeCats is the new merge function, used the same way as utils.mergeCatDefs

In addition, module options for categoryDefininions have been slightly changed.

replace still uses mergeCatDefs and merge now uses utils.deepmergeCats

Using replace no longer is what controls if definitions from the package the module was based on are inherited.

Instead, an extra option has been added, to allow you to control the merge strategy used for merging with the existing definitions.