### PR TITLE
Module consistency

### DIFF
--- a/nixCatsHelp/nixCats_modules.txt
+++ b/nixCatsHelp/nixCats_modules.txt
@@ -57,16 +57,13 @@ other than the packages themselves in config.${defaultPackageName}.out
         default = [];
         type = (types.listOf types.anything);
         description = ''
-          A list of overlays to make available to nixCats but not to your system.
+          A list of overlays to make available to any nixCats package from this module but not to your system.
           Will have access to system overlays regardless of this setting.
         '';
         example = (lib.literalExpression ''
-          addOverlays = [ (self: super: { vimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+          addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
         '');
       };
-
-      # the above 2 are the only ones not also available at
-      # a per-user level in the nixos system module.
 
       enable = mkOption {
         default = false;
@@ -134,53 +131,109 @@ other than the packages themselves in config.${defaultPackageName}.out
         };
       };
 
-      packages = mkOption {
-        default = null;
-        description = ''
-          VERY IMPORTANT when setting aliases for each package,
-          they must not be the same as ANY other neovim package for that user.
-          It will cause a build conflict.
+      packageDefinitions = {
+        existing = mkOption {
+          default = "replace";
+          type = types.enum [ "replace" "merge" "discard" ];
+          description = ''
+            the merge strategy to use for packageDefinitions inherited from the package this module was based on
+            choose between "replace", "merge" or "discard"
+            replace uses utils.mergeCatDefs
+            merge uses utils.deepmergeCats
+            discard does not inherit
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+          '';
+        };
+        merge = mkOption {
+          default = null;
+          description = ''
+            VERY IMPORTANT when setting aliases for each package,
+            they must not be the same as ANY other neovim package for that user.
+            It will cause a build conflict.
 
-          You can have as many nixCats installed per user as you want,
-          as long as you obey that rule.
+            You can have as many nixCats installed per user as you want,
+            as long as you obey that rule.
 
-          for information on the values you may return,
-          see :help nixCats.flake.outputs.settings
-          and :help nixCats.flake.outputs.categories
-        '';
-        type = with types; nullOr (attrsOf (catDef "replace"));
-        example = ''
-          nixCats.packages = { 
-            nixCats = { pkgs, ... }: {
-              settings = {
-                wrapRc = true;
-                configDirName = "nixCats-nvim";
-                # nvimSRC = inputs.neovim;
-                aliases = [ "vim" "nixCats" ];
+            for information on the values you may return,
+            see :help nixCats.flake.outputs.settings
+            and :help nixCats.flake.outputs.categories
+          '';
+          type = with types; nullOr (attrsOf (catDef "replace"));
+          example = ''
+            nixCats.packages = { 
+              nixCats = { pkgs, ... }: {
+                settings = {
+                  wrapRc = true;
+                  configDirName = "nixCats-nvim";
+                  # nvimSRC = inputs.neovim;
+                  aliases = [ "vim" "nixCats" ];
+                };
+                categories = {
+                  generalBuildInputs = true;
+                  markdown = true;
+                  gitPlugins = true;
+                  general = true;
+                  custom = true;
+                  neonixdev = true;
+                  debug = false;
+                  test = true;
+                  lspDebugMode = false;
+                  themer = true;
+                  colorscheme = "onedark";
+                };
               };
-              categories = {
-                generalBuildInputs = true;
-                markdown = true;
-                gitPlugins = true;
-                general = true;
-                custom = true;
-                neonixdev = true;
-                debug = false;
-                test = true;
-                lspDebugMode = false;
-                themer = true;
-                colorscheme = "onedark";
+            }
+          '';
+        };
+        replace = mkOption {
+          default = null;
+          description = ''
+            VERY IMPORTANT when setting aliases for each package,
+            they must not be the same as ANY other neovim package for that user.
+            It will cause a build conflict.
+
+            You can have as many nixCats installed per user as you want,
+            as long as you obey that rule.
+
+            for information on the values you may return,
+            see :help nixCats.flake.outputs.settings
+            and :help nixCats.flake.outputs.categories
+          '';
+          type = with types; nullOr (attrsOf (catDef "replace"));
+          example = ''
+            nixCats.packages = { 
+              nixCats = { pkgs, ... }: {
+                settings = {
+                  wrapRc = true;
+                  configDirName = "nixCats-nvim";
+                  # nvimSRC = inputs.neovim;
+                  aliases = [ "vim" "nixCats" ];
+                };
+                categories = {
+                  generalBuildInputs = true;
+                  markdown = true;
+                  gitPlugins = true;
+                  general = true;
+                  custom = true;
+                  neonixdev = true;
+                  debug = false;
+                  test = true;
+                  lspDebugMode = false;
+                  themer = true;
+                  colorscheme = "onedark";
+                };
               };
-            };
-          }
-        '';
+            }
+          '';
+        };
       };
+
+      # in addition, the nixos module also has per-user options if desired.
 
       users = mkOption {
         default = {};
         description = ''
           same as system config but per user instead
-          and without addOverlays or nixpkgs_version
         '';
         type = with types; attrsOf (submodule {
           options = {

--- a/templates/module/homeCat.nix
+++ b/templates/module/homeCat.nix
@@ -81,7 +81,7 @@ in {
       });
 
       # see :help nixCats.flake.outputs.packageDefinitions
-      packages = {
+      packageDefinitions.replace = {
         # These are the names of your packages
         # you can include as many as you wish.
         myHomeModuleNvim = {pkgs , ... }: {

--- a/templates/module/systemCat.nix
+++ b/templates/module/systemCat.nix
@@ -83,7 +83,7 @@ in {
       });
 
       # see :help nixCats.flake.outputs.packageDefinitions
-      packages = {
+      packageDefinitions.replace = {
         # These are the names of your packages
         # you can include as many as you wish.
         myNixModuleNvim = {pkgs , ... }: {
@@ -173,7 +173,7 @@ in {
             test = [ (_:[]) ];
           };
         });
-        packages = {
+        packageDefinitions.replace = {
           REPLACE_MEs_VIM = {pkgs, ...}: {
             settings = {
               wrapRc = true;

--- a/tests/home/main.nix
+++ b/tests/home/main.nix
@@ -18,7 +18,7 @@ in {
   ${packagename} = {
     enable = true;
     packageNames = [ packagename ];
-    packages = {
+    packageDefinitions.replace = {
       ${packagename} = utils.mergeCatDefs package.packageDefinitions.${packagename} ({ pkgs, ... }: {
         settings = {
         };

--- a/tests/nixos/main.nix
+++ b/tests/nixos/main.nix
@@ -2,7 +2,7 @@
   ${packagename} = {
     enable = true;
     packageNames = [ packagename ];
-    packages = {
+    packageDefinitions.replace = {
       ${packagename} = utils.mergeCatDefs package.packageDefinitions.${packagename} ({ pkgs, ... }: {
         settings = {
         };

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -603,13 +603,21 @@ in {
     newUserPackageDefinitions = builtins.mapAttrs ( uname: _: let
       user_options_set = config.${defaultPackageName}.users.${uname};
       in {
-        packages = lib.mkIf user_options_set.enable (builtins.attrValues (mapToPackages user_options_set (dependencyOverlaysFunc { inherit main_options_set user_options_set; }) [ defaultPackageName "users" uname ]));
+        packages = lib.mkIf user_options_set.enable (builtins.attrValues (mapToPackages
+          user_options_set
+          (dependencyOverlaysFunc { inherit main_options_set user_options_set; })
+          [ defaultPackageName "users" uname ]
+        ));
       }
     ) config.${defaultPackageName}.users;
     newUserPackageOutputs = builtins.mapAttrs ( uname: _: let
       user_options_set = config.${defaultPackageName}.users.${uname};
       in {
-        packages = lib.mkIf user_options_set.enable (mapToPackages user_options_set (dependencyOverlaysFunc { inherit main_options_set user_options_set; }) [ defaultPackageName "users" uname ]);
+        packages = lib.mkIf user_options_set.enable (mapToPackages
+          user_options_set
+          (dependencyOverlaysFunc { inherit main_options_set user_options_set; })
+          [ defaultPackageName "users" uname ]
+        );
       }
     ) config.${defaultPackageName}.users;
   in {

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -41,7 +41,7 @@ in {
           Will have access to system overlays regardless of this setting.
         '';
         example = (lib.literalExpression ''
-          addOverlays = [ (self: super: { vimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+          addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
         '');
       };
 
@@ -275,7 +275,7 @@ in {
                 This per user version of addOverlays is merged with the value of ${defaultPackageName}.addOverlays 
               '';
               example = (lib.literalExpression ''
-                addOverlays = [ (self: super: { vimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+                addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
               '');
             };
 

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -37,7 +37,7 @@ in {
         default = [];
         type = (types.listOf types.anything);
         description = ''
-          A list of overlays to make available to nixCats but not to your system.
+          A list of overlays to make available to any nixCats package from this module but not to your system.
           Will have access to system overlays regardless of this setting.
         '';
         example = (lib.literalExpression ''
@@ -244,7 +244,6 @@ in {
         default = {};
         description = ''
           same as system config but per user instead
-          and without addOverlays or nixpkgs_version
         '';
         type = with types; attrsOf (submodule {
           options = {
@@ -270,7 +269,8 @@ in {
               default = [];
               type = (types.listOf types.anything);
               description = ''
-                A list of overlays to make available to nixCats but not to your system.
+                A list of overlays to make available to
+                this user's nixCats packages from this module but not to your system.
                 Will have access to system overlays regardless of this setting.
                 This per user version of addOverlays is merged with the value of ${defaultPackageName}.addOverlays 
               '';

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -551,7 +551,7 @@ in {
           newAttrs = if builtins.isAttrs new then new else {};
           merged = builtins.mapAttrs (n: v: if oldAttrs ? ${n} then strat oldAttrs.${n} v else v) newAttrs;
         in
-        old // merged;
+        oldAttrs // merged;
         stratWithExisting = getStratWithExisting options_set.packageDefinitions.existing;
         modulePkgDefs = let
           # TODO: this `repments` step can be removed when options_set.packages is removed

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -111,6 +111,12 @@ in {
         };
       };
 
+      packages = mkOption {
+        default = null;
+        type = with types; nullOr (attrsOf (catDef "replace"));
+        visible = false;
+      };
+
       packageDefinitions = {
         existing = mkOption {
           default = "replace";
@@ -206,48 +212,6 @@ in {
             }
           '';
         };
-      };
-
-      packages = mkOption {
-        default = null;
-        description = ''
-          VERY IMPORTANT when setting aliases for each package,
-          they must not be the same as ANY other neovim package for that user.
-          It will cause a build conflict.
-
-          You can have as many nixCats installed per user as you want,
-          as long as you obey that rule.
-
-          for information on the values you may return,
-          see :help nixCats.flake.outputs.settings
-          and :help nixCats.flake.outputs.categories
-        '';
-        type = with types; nullOr (attrsOf (catDef "replace"));
-        example = ''
-          nixCats.packages = { 
-            nixCats = { pkgs, ... }: {
-              settings = {
-                wrapRc = true;
-                configDirName = "nixCats-nvim";
-                # nvimSRC = inputs.neovim;
-                aliases = [ "vim" "nixCats" ];
-              };
-              categories = {
-                generalBuildInputs = true;
-                markdown = true;
-                gitPlugins = true;
-                general = true;
-                custom = true;
-                neonixdev = true;
-                debug = false;
-                test = true;
-                lspDebugMode = false;
-                themer = true;
-                colorscheme = "onedark";
-              };
-            };
-          }
-        '';
       };
 
       out = {
@@ -375,6 +339,12 @@ in {
               };
             };
 
+            packages = mkOption {
+              default = null;
+              type = with types; nullOr (attrsOf (catDef "replace"));
+              visible = false;
+            };
+
             packageDefinitions = {
               existing = mkOption {
                 default = "replace";
@@ -470,48 +440,6 @@ in {
                   }
                 '';
               };
-            };
-
-            packages = mkOption {
-              default = null;
-              description = ''
-                VERY IMPORTANT when setting aliases for each package,
-                they must not be the same as ANY other neovim package for that user.
-                It will cause a build conflict.
-
-                You can have as many nixCats installed per user as you want,
-                as long as you obey that rule.
-
-                for information on the values you may return,
-                see :help nixCats.flake.outputs.settings
-                and :help nixCats.flake.outputs.categories
-              '';
-              type = with types; nullOr (attrsOf (catDef "replace"));
-              example = ''
-                nixCats.packages = { 
-                  nixCats = { pkgs, ... }: {
-                    settings = {
-                      wrapRc = true;
-                      configDirName = "nixCats-nvim";
-                      # nvimSRC = inputs.neovim;
-                      aliases = [ "vim" "nixCats" ];
-                    };
-                    categories = {
-                      generalBuildInputs = true;
-                      markdown = true;
-                      gitPlugins = true;
-                      general = true;
-                      custom = true;
-                      neonixdev = true;
-                      debug = false;
-                      test = true;
-                      lspDebugMode = false;
-                      themer = true;
-                      colorscheme = "onedark";
-                    };
-                  };
-                }
-              '';
             };
 
           };

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -116,7 +116,7 @@ in {
           default = "replace";
           type = types.enum [ "replace" "merge" "discard" ];
           description = ''
-            the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+            the merge strategy to use for packageDefinitions inherited from the package this module was based on
             choose between "replace", "merge" or "discard"
             replace uses utils.mergeCatDefs
             merge uses utils.deepmergeCats

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -538,7 +538,7 @@ in {
           '') (pkgmerger utils.mergeCatDefs options_set.packages options_set.packageDefinitions.replace)
             else options_set.packageDefinitions.replace;
         in
-        pkgmerger utils.mergeCatDefs repments options_set.packageDefinitions.merge;
+        pkgmerger utils.deepmergeCats repments options_set.packageDefinitions.merge;
       in pkgmerger stratWithExisting packageDefinitions modulePkgDefs;
 
       newLuaBuilder = (if options_set.luaPath != "" then (utils.baseBuilder options_set.luaPath)

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -111,6 +111,103 @@ in {
         };
       };
 
+      packageDefinitions = {
+        existing = mkOption {
+          default = "replace";
+          type = types.enum [ "replace" "merge" "discard" ];
+          description = ''
+            the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+            choose between "replace", "merge" or "discard"
+            replace uses utils.mergeCatDefs
+            merge uses utils.deepmergeCats
+            discard does not inherit
+            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+          '';
+        };
+        merge = mkOption {
+          default = null;
+          description = ''
+            VERY IMPORTANT when setting aliases for each package,
+            they must not be the same as ANY other neovim package for that user.
+            It will cause a build conflict.
+
+            You can have as many nixCats installed per user as you want,
+            as long as you obey that rule.
+
+            for information on the values you may return,
+            see :help nixCats.flake.outputs.settings
+            and :help nixCats.flake.outputs.categories
+          '';
+          type = with types; nullOr (attrsOf (catDef "replace"));
+          example = ''
+            nixCats.packages = { 
+              nixCats = { pkgs, ... }: {
+                settings = {
+                  wrapRc = true;
+                  configDirName = "nixCats-nvim";
+                  # nvimSRC = inputs.neovim;
+                  aliases = [ "vim" "nixCats" ];
+                };
+                categories = {
+                  generalBuildInputs = true;
+                  markdown = true;
+                  gitPlugins = true;
+                  general = true;
+                  custom = true;
+                  neonixdev = true;
+                  debug = false;
+                  test = true;
+                  lspDebugMode = false;
+                  themer = true;
+                  colorscheme = "onedark";
+                };
+              };
+            }
+          '';
+        };
+        replace = mkOption {
+          default = null;
+          description = ''
+            VERY IMPORTANT when setting aliases for each package,
+            they must not be the same as ANY other neovim package for that user.
+            It will cause a build conflict.
+
+            You can have as many nixCats installed per user as you want,
+            as long as you obey that rule.
+
+            for information on the values you may return,
+            see :help nixCats.flake.outputs.settings
+            and :help nixCats.flake.outputs.categories
+          '';
+          type = with types; nullOr (attrsOf (catDef "replace"));
+          example = ''
+            nixCats.packages = { 
+              nixCats = { pkgs, ... }: {
+                settings = {
+                  wrapRc = true;
+                  configDirName = "nixCats-nvim";
+                  # nvimSRC = inputs.neovim;
+                  aliases = [ "vim" "nixCats" ];
+                };
+                categories = {
+                  generalBuildInputs = true;
+                  markdown = true;
+                  gitPlugins = true;
+                  general = true;
+                  custom = true;
+                  neonixdev = true;
+                  debug = false;
+                  test = true;
+                  lspDebugMode = false;
+                  themer = true;
+                  colorscheme = "onedark";
+                };
+              };
+            }
+          '';
+        };
+      };
+
       packages = mkOption {
         default = null;
         description = ''
@@ -253,6 +350,103 @@ in {
               };
             };
 
+            packageDefinitions = {
+              existing = mkOption {
+                default = "replace";
+                type = types.enum [ "replace" "merge" "discard" ];
+                description = ''
+                  the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+                  choose between "replace", "merge" or "discard"
+                  replace uses utils.mergeCatDefs
+                  merge uses utils.deepmergeCats
+                  discard does not inherit
+                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+                '';
+              };
+              merge = mkOption {
+                default = null;
+                description = ''
+                  VERY IMPORTANT when setting aliases for each package,
+                  they must not be the same as ANY other neovim package for that user.
+                  It will cause a build conflict.
+
+                  You can have as many nixCats installed per user as you want,
+                  as long as you obey that rule.
+
+                  for information on the values you may return,
+                  see :help nixCats.flake.outputs.settings
+                  and :help nixCats.flake.outputs.categories
+                '';
+                type = with types; nullOr (attrsOf (catDef "replace"));
+                example = ''
+                  nixCats.users.<USER>.packages = { 
+                    nixCats = { pkgs, ... }: {
+                      settings = {
+                        wrapRc = true;
+                        configDirName = "nixCats-nvim";
+                        # nvimSRC = inputs.neovim;
+                        aliases = [ "vim" "nixCats" ];
+                      };
+                      categories = {
+                        generalBuildInputs = true;
+                        markdown = true;
+                        gitPlugins = true;
+                        general = true;
+                        custom = true;
+                        neonixdev = true;
+                        debug = false;
+                        test = true;
+                        lspDebugMode = false;
+                        themer = true;
+                        colorscheme = "onedark";
+                      };
+                    };
+                  }
+                '';
+              };
+              replace = mkOption {
+                default = null;
+                description = ''
+                  VERY IMPORTANT when setting aliases for each package,
+                  they must not be the same as ANY other neovim package for that user.
+                  It will cause a build conflict.
+
+                  You can have as many nixCats installed per user as you want,
+                  as long as you obey that rule.
+
+                  for information on the values you may return,
+                  see :help nixCats.flake.outputs.settings
+                  and :help nixCats.flake.outputs.categories
+                '';
+                type = with types; nullOr (attrsOf (catDef "replace"));
+                example = ''
+                  nixCats.users.<USER>.packages = { 
+                    nixCats = { pkgs, ... }: {
+                      settings = {
+                        wrapRc = true;
+                        configDirName = "nixCats-nvim";
+                        # nvimSRC = inputs.neovim;
+                        aliases = [ "vim" "nixCats" ];
+                      };
+                      categories = {
+                        generalBuildInputs = true;
+                        markdown = true;
+                        gitPlugins = true;
+                        general = true;
+                        custom = true;
+                        neonixdev = true;
+                        debug = false;
+                        test = true;
+                        lspDebugMode = false;
+                        themer = true;
+                        colorscheme = "onedark";
+                      };
+                    };
+                  }
+                '';
+              };
+            };
+
             packages = mkOption {
               default = null;
               description = ''
@@ -294,6 +488,7 @@ in {
                 }
               '';
             };
+
           };
         });
       };
@@ -301,6 +496,21 @@ in {
   };
 
   config = let
+    combineModDeps = replacements: merges: utils.deepmergeCats (
+      if replacements != null then replacements else (_:{})
+    ) (
+      if merges != null then merges else (_:{})
+    );
+    getStratWithExisting = enumstr: if enumstr == "merge"
+      then utils.deepmergeCats
+      else if enumstr == "replace"
+      then utils.mergeCatDefs
+      else (_: r: r);
+    pkgmerger = strat: old: new: let
+      merged = builtins.mapAttrs (n: v: if (if builtins.isAttrs old then old else {}) ? ${n} then strat old.${n} v else v) new;
+    in
+    old // merged;
+
     options_set = config.${defaultPackageName};
     dependencyOverlays = if builtins.isAttrs oldDependencyOverlays then
         lib.genAttrs (builtins.attrNames oldDependencyOverlays)
@@ -309,23 +519,29 @@ in {
       pkgs.overlays ++ [(utils.mergeOverlayLists oldDependencyOverlays options_set.addOverlays)]
       else pkgs.overlays ++ options_set.addOverlays;
 
-    mapToPackages = options_set: dependencyOverlays: (let
+    mapToPackages = options_set: dependencyOverlays: atp: (let
       newCategoryDefinitions = let
-        stratWithExisting = if options_set.categoryDefinitions.existing == "merge"
-          then utils.deepmergeCats
-          else if options_set.categoryDefinitions.existing == "replace"
-          then utils.mergeCatDefs
-          else (_: r: r);
-
-        moduleCatDefs = utils.deepmergeCats (
-          if options_set.categoryDefinitions.replace != null then options_set.categoryDefinitions.replace else (_:{})
-        ) (
-          if options_set.categoryDefinitions.merge != null then options_set.categoryDefinitions.merge else (_:{})
-        );
+        stratWithExisting = getStratWithExisting options_set.categoryDefinitions.existing;
+        moduleCatDefs = combineModDeps options_set.categoryDefinitions.replace options_set.categoryDefinitions.merge;
       in stratWithExisting categoryDefinitions moduleCatDefs;
 
-      pkgDefs = if (options_set.packages != null)
-        then packageDefinitions // options_set.packages else packageDefinitions;
+      pkgDefs = let
+        stratWithExisting = getStratWithExisting options_set.packageDefinitions.existing;
+        modulePkgDefs = let
+          # TODO: this `repments` step can be removed when options_set.packages is removed
+          # In addition, `mapToPackages` will once again no longer need to know its attrpath
+          repments = if options_set.packages != null then builtins.trace (let
+            basepath = builtins.concatStringsSep "." atp;
+          in ''
+            Deprecation warning: ${basepath}.packages renamed to: ${basepath}.packageDefinitions.replace
+            Done in order to achieve consistency with categoryDefinitions module options, and provide better control
+          '') (pkgmerger utils.mergeCatDefs options_set.packages (if options_set.packageDefinitions.replace != null then options_set.packageDefinitions.replace else {}))
+            else options_set.packageDefinitions.replace;
+          reps = if repments != null then repments else {};
+          merges = if options_set.packageDefinitions.merge != null then options_set.packageDefinitions.merge else {};
+        in
+        pkgmerger utils.mergeCatDefs reps merges;
+      in pkgmerger stratWithExisting packageDefinitions modulePkgDefs;
 
       newLuaBuilder = (if options_set.luaPath != "" then (utils.baseBuilder options_set.luaPath)
         else 
@@ -347,7 +563,7 @@ in {
         { name = catName; value = boxedCat; }) options_set.packageNames))
     );
 
-    mappedPackageAttrs = mapToPackages options_set dependencyOverlays;
+    mappedPackageAttrs = mapToPackages options_set dependencyOverlays [ "${defaultPackageName}" ];
     mappedPackages = builtins.attrValues mappedPackageAttrs;
 
   in
@@ -364,7 +580,7 @@ in {
     newUserPackageOutputs = builtins.mapAttrs ( uname: _: let
       user_options_set = config.${defaultPackageName}.users.${uname};
       in {
-        packages = lib.mkIf options_set.enable (mapToPackages user_options_set dependencyOverlays);
+        packages = lib.mkIf options_set.enable (mapToPackages user_options_set dependencyOverlays [ defaultPackageName "users" uname ]);
       }
     ) config.${defaultPackageName}.users;
   in {


### PR DESCRIPTION
Breaking:

`${defaultPackageName}.packages` module option renamed to `${defaultPackageName}.packageDefinitions.replace`

Depreciation warning for the above changed added.

Non-Breaking, option additions for consistency:

In addition, the rest of the options to mirror `categoryDefinitions` module options have been added
`${defaultPackageName}.packageDefinitions.merge`
`${defaultPackageName}.packageDefinitions.existing`

nixos module gained the ability to set nixpkgs version or add overlays per user if desired, so that user options fully mirror system ones.