### PR TITLE
Dont install module option

### DIFF
--- a/nixCatsHelp/nixCats_modules.txt
+++ b/nixCatsHelp/nixCats_modules.txt
@@ -71,6 +71,15 @@ other than the packages themselves in config.${defaultPackageName}.out
         description = "Enable the ${defaultPackageName} module";
       };
 
+      dontInstall = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          If true, do not output to packages list,
+          output only to config.${defaultPackageName}.out
+        '';
+      };
+
       luaPath = mkOption {
         default = luaPath;
         type = types.oneOf [ types.str types.path ];

--- a/utils/mkModules.nix
+++ b/utils/mkModules.nix
@@ -548,16 +548,6 @@ in {
     ${defaultPackageName}.out.packages = lib.mkIf main_options_set.enable mappedPackageAttrs;
     home.packages = lib.mkIf (main_options_set.enable && ! main_options_set.dontInstall) mappedPackages;
   } else (let
-    newUserPackageDefinitions = builtins.mapAttrs ( uname: _: let
-      user_options_set = config.${defaultPackageName}.users.${uname};
-      in {
-        packages = lib.mkIf (user_options_set.enable && ! user_options_set.dontInstall) (builtins.attrValues (mapToPackages
-          user_options_set
-          (dependencyOverlaysFunc { inherit main_options_set user_options_set; })
-          [ defaultPackageName "users" uname ]
-        ));
-      }
-    ) config.${defaultPackageName}.users;
     newUserPackageOutputs = builtins.mapAttrs ( uname: _: let
       user_options_set = config.${defaultPackageName}.users.${uname};
       in {
@@ -566,6 +556,12 @@ in {
           (dependencyOverlaysFunc { inherit main_options_set user_options_set; })
           [ defaultPackageName "users" uname ]
         );
+      }
+    ) config.${defaultPackageName}.users;
+    newUserPackageDefinitions = builtins.mapAttrs ( uname: _: let
+      user_options_set = config.${defaultPackageName}.users.${uname};
+      in {
+        packages = lib.mkIf (user_options_set.enable && ! user_options_set.dontInstall) (builtins.attrValues newUserPackageOutputs.${uname}.packages);
       }
     ) config.${defaultPackageName}.users;
   in {


### PR DESCRIPTION
Add ability for modules to choose to not install the packages to the packages list, instead only outputting to `config.${defaultPackageName}.out`

I am unsure as to the usefulness of this feature, but it may allow something cool eventually.