### PR TITLE
Improvements for the nixCats lua plugin

### DIFF
--- a/builder/builder_error.nix
+++ b/builder/builder_error.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 builtins.throw ''
   The following arguments are accepted:
 

--- a/builder/ncTools.nix
+++ b/builder/ncTools.nix
@@ -2,6 +2,26 @@
 # Licensed under the MIT license 
 { lib, ... }: with builtins; rec {
 # NIX CATS INTERNAL UTILS:
+
+  mkLuaFileWithMeta = { writeText }: modname: table: writeText "${modname}.lua" /*lua*/''
+    local ${modname} = ${toLua table};
+    return setmetatable(${modname}, {
+      __call = function(self, attrpath)
+        local strtable = {}
+        if type(attrpath) == "table" then
+            strtable = attrpath
+        elseif type(attrpath) == "string" then
+            for key in attrpath:gmatch("([^%.]+)") do
+                table.insert(strtable, key)
+            end
+        else
+            print("function requires a table of strings or a dot separated string")
+            return
+        end
+        return vim.tbl_get(${modname}, unpack(strtable));
+      end
+    })
+  '';
   
   mkLuaInline = expr: { __type = "nix-to-lua-inline"; inherit expr; };
 

--- a/builder/nixCatsMeta.lua
+++ b/builder/nixCatsMeta.lua
@@ -3,17 +3,33 @@
 ---@meta
 error("Cannot import a meta module")
 
----@class nixCats
----@field cats table
----@field pawsible table
----@field settings table
----@field petShop table
+---@class nixCats.main
+---See :h nixCats.flake.outputs.packageDefinitions
+---Function form will return vim.tml_get for the attrpath
+---@field cats table|fun(attrpath: string|string[]): any
+---See :h nixCats.flake.outputs.settings
+---Function form will return vim.tml_get for the attrpath
+---@field settings table|fun(attrpath: string|string[]): any
+---Contains the final set of plugins added for this package
+---Function form will return vim.tml_get for the attrpath
+---@field pawsible table|fun(attrpath: string|string[]): any
+---Contains all the defined categories that you COULD enable from nix
+---Function form will return vim.tml_get for the attrpath
+---@field petShop table|fun(attrpath: string|string[]): any
 ---@field nixCatsPath string
 ---@field vimPackDir string
 ---@field configDir string
 ---@field packageBinPath string
 ---internal: this creates the nixCats global commands
 ---@field addGlobals fun() 
----internal: use the global alias, nixCats('path.to.value')
----for full compatibility with luaUtils template
----@field get fun(category: string|string[]): any --
+---:h nixCats
+---This function will return the nearest parent category value, unless the nearest
+---parent is a table, in which case that means a different subcategory
+---was enabled but this one was not. In that case it returns nil.
+---@field get fun(category: string|string[]): any
+
+---:h nixCats
+---This function will return the nearest parent category value, unless the nearest
+---parent is a table, in which case that means a different subcategory
+---was enabled but this one was not. In that case it returns nil.
+---@alias nixCats nixCats.main | fun(category: string|string[]): any

--- a/builder/vim-pack-dir.nix
+++ b/builder/vim-pack-dir.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 # derived from:
 # https://github.com/NixOS/nixpkgs/blob/ae5d2af73efa5e25bf9bf43672cd3d8d99c613d0/pkgs/applications/editors/vim/plugins/vim-utils.nix#L136-L207
 { lib, buildEnv, writeTextFile
@@ -44,7 +46,6 @@
         start = builtins.listToAttrs (map mkEntryFromDrv startPlugins);
         opt = builtins.listToAttrs (map mkEntryFromDrv opt);
         inherit ts_grammar_path;
-        ts_grammar_plugin = ts_grammar_path;
       };
       python3Path = if (allPython3Dependencies python3.pkgs == []) then null
         else ''${python3link}/pack/${packageName}/start/__python3_dependencies/python3'';

--- a/builder/wrapNeovim.nix
+++ b/builder/wrapNeovim.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 # derived from:
 # https://github.com/NixOS/nixpkgs/blob/8564cb1517f118e1e90b8bc9ba052678f1aa4603/pkgs/applications/editors/neovim/utils.nix#L126-L164
 {

--- a/builder/wrapenvs.nix
+++ b/builder/wrapenvs.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 # derived from:
 # https://github.com/NixOS/nixpkgs/blob/8564cb1517f118e1e90b8bc9ba052678f1aa4603/pkgs/applications/editors/neovim/utils.nix#L26-L122
 { withPython3 ? true

--- a/builder/wrapper.nix
+++ b/builder/wrapper.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 # Derived from:
 # https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/neovim/wrapper.nix
 { stdenv
@@ -96,15 +98,14 @@ let
       vim.opt.runtimepath:prepend([[${finalPackDir}]])
       vim.g[ [[nixCats-special-rtp-entry-vimPackDir]] ] = [[${finalPackDir}]]
       vim.g[ [[nixCats-special-rtp-entry-nvimLuaEnv]] ] = [[${luaEnv}]]
-      require('nixCats').addGlobals()
-      vim.g.configdir = vim.fn.stdpath('config')
-      vim.opt.packpath:remove(vim.g.configdir)
-      vim.opt.runtimepath:remove(vim.g.configdir)
-      vim.opt.runtimepath:remove(vim.g.configdir .. "/after")
-      vim.g.configdir = require('nixCats').cats.nixCats_config_location
-      vim.opt.packpath:prepend(vim.g.configdir)
-      vim.opt.runtimepath:prepend(vim.g.configdir)
-      vim.opt.runtimepath:append(vim.g.configdir .. "/after")
+      local configdir = vim.fn.stdpath('config')
+      vim.opt.packpath:remove(configdir)
+      vim.opt.runtimepath:remove(configdir)
+      vim.opt.runtimepath:remove(configdir .. "/after")
+      configdir = require('nixCats').configDir
+      vim.opt.packpath:prepend(configdir)
+      vim.opt.runtimepath:prepend(configdir)
+      vim.opt.runtimepath:append(configdir .. "/after")
     '';
   in [
     # vim accepts a limited number of commands so we join them all

--- a/nixCatsHelp/nixCats_plugin.txt
+++ b/nixCatsHelp/nixCats_plugin.txt
@@ -104,6 +104,8 @@ Using:
 >vim
     :lua print(vim.inspect(require('nixCats').cats))
     or
+    :lua print(vim.inspect(nixCats.cats))
+    or
     :NixCats
     or
     :NixCats cats
@@ -181,16 +183,16 @@ Use this fact as you wish.
 You could use it to pass information like port numbers or paths
 Or whatever else you want.
 
-In addition to `require('nixCats').cats`, nixCats also contains other info.
+In addition to `nixCats.cats`, nixCats also contains other info.
 
 >lua
-  require('nixCats').pawsible
-    -- contains a final list of all the plugins included
+  nixCats.pawsible
+    -- contains a final set of all the plugins included
     -- in the package and their paths, and the path to treesitter parsers.
     -- does not include lsps and runtime dependencies,
     -- you can retrieve their paths with vim.fn.exepath if needed.
 
-  require('nixCats').settings
+  nixCats.settings
     -- contains the settings set for the package
 <
 
@@ -216,22 +218,37 @@ lua.
 All of the following may be accessed by `require('nixCats').<item>`,
 or :NixCats <item>, except the :NixCats user command also
 has the `cat` subcommand to preview the value from `nixCats("catname")`,
-and doesnt show the ones marked as internal
 >lua
-  ---@class nixCats
-  ---@field cats table
-  ---@field pawsible table
-  ---@field settings table
-  ---@field petShop table
+  ---@class nixCats.main
+  ---See :h nixCats.flake.outputs.packageDefinitions
+  ---Function form will return vim.tml_get for the attrpath
+  ---@field cats table|fun(attrpath: string|string[]): any
+  ---See :h nixCats.flake.outputs.settings
+  ---Function form will return vim.tml_get for the attrpath
+  ---@field settings table|fun(attrpath: string|string[]): any
+  ---Contains the final set of plugins added for this package
+  ---Function form will return vim.tml_get for the attrpath
+  ---@field pawsible table|fun(attrpath: string|string[]): any
+  ---Contains all the defined categories that you COULD enable from nix
+  ---Function form will return vim.tml_get for the attrpath
+  ---@field petShop table|fun(attrpath: string|string[]): any
   ---@field nixCatsPath string
   ---@field vimPackDir string
   ---@field configDir string
   ---@field packageBinPath string
   ---internal: this creates the nixCats global commands
   ---@field addGlobals fun() 
-  ---internal: use the global alias, nixCats('path.to.value')
-  ---for full compatibility with luaUtils template
-  ---@field get fun(category: string|string[]): any --
+  ---:h nixCats
+  ---This function will return the nearest parent category value, unless the nearest
+  ---parent is a table, in which case that means a different subcategory
+  ---was enabled but this one was not. In that case it returns nil.
+  ---@field get fun(category: string|string[]): any
+
+  ---:h nixCats
+  ---This function will return the nearest parent category value, unless the nearest
+  ---parent is a table, in which case that means a different subcategory
+  ---was enabled but this one was not. In that case it returns nil.
+  ---@alias nixCats nixCats.main | fun(category: string|string[]): any
 <
 ----------------------------------------------------------------------------------------
 vim:tw=78:ts=8:ft=help:norl:

--- a/templates/example/lua/nixCatsUtils/init.lua
+++ b/templates/example/lua/nixCatsUtils/init.lua
@@ -3,6 +3,7 @@ local M = {}
 -- This directory is the luaUtils template.
 -- the other 3 files are intended to be independent, but may depend on this one.
 -- You will likely want at least something in this one,
+-- and if you use lze or lz.n you should check out lzUtils.lua
 -- but unless you use lazy.nvm or want to use pckr or rocks when not on nix, you wont need the other 2
 
 ---@type boolean
@@ -11,7 +12,10 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---@class nixCatsSetupOpts
 ---@field non_nix_value boolean|nil
 
----defaults to true if non_nix_value is not provided or is not a boolean.
+---This function will setup a mock nixCats plugin when not using nix
+---It will help prevent you from running into indexing errors without a nixCats plugin from nix.
+---If you loaded the config via nix, it does nothing
+---non_nix_value defaults to true if not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
   if not M.isNixCats then
@@ -21,29 +25,50 @@ function M.setup(v)
     else
       nixCats_default_value = true
     end
-    -- if not in nix, just make it return a boolean
-    require('_G').nixCats = function(_) return nixCats_default_value end
-    -- and define some stuff for the nixCats plugin
-    -- to prevent indexing errors and provide some values
+    local mk_with_meta = function (tbl)
+      return setmetatable(tbl, {
+        __call = function(_, attrpath)
+          local strtable = {}
+          if type(attrpath) == "table" then
+              strtable = attrpath
+          elseif type(attrpath) == "string" then
+              for key in attrpath:gmatch("([^%.]+)") do
+                  table.insert(strtable, key)
+              end
+          else
+              print("function requires a table of strings or a dot separated string")
+              return
+          end
+          return vim.tbl_get(tbl, unpack(strtable));
+        end
+      })
+    end
     package.preload['nixCats'] = function ()
-      return {
-        cats = {},
-        pawsible = {
-          allPlugins = {
-            start = {},
-            opt = {},
-            ts_grammar_path = nil,
-          },
-        },
-        settings = {
+      local ncsub = {
+        get = function(_) return nixCats_default_value end,
+        cats = mk_with_meta({
           nixCats_config_location = vim.fn.stdpath('config'),
           configDirName = os.getenv("NVIM_APPNAME") or "nvim",
           wrapRc = false,
-        },
+        }),
+        settings = mk_with_meta({
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        }),
+        petShop = mk_with_meta({}),
+        pawsible = mk_with_meta({
+          allPlugins = {
+            start = {},
+            opt = {},
+          },
+        }),
         configDir = vim.fn.stdpath('config'),
         packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
       }
+      return setmetatable(ncsub, {__call = function(_, cat) return ncsub.get(cat) end})
     end
+    _G.nixCats = require('nixCats')
   end
 end
 

--- a/templates/kickstart-nvim/lua/nixCatsUtils/init.lua
+++ b/templates/kickstart-nvim/lua/nixCatsUtils/init.lua
@@ -3,6 +3,7 @@ local M = {}
 -- This directory is the luaUtils template.
 -- the other 3 files are intended to be independent, but may depend on this one.
 -- You will likely want at least something in this one,
+-- and if you use lze or lz.n you should check out lzUtils.lua
 -- but unless you use lazy.nvm or want to use pckr or rocks when not on nix, you wont need the other 2
 
 ---@type boolean
@@ -11,7 +12,10 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---@class nixCatsSetupOpts
 ---@field non_nix_value boolean|nil
 
----defaults to true if non_nix_value is not provided or is not a boolean.
+---This function will setup a mock nixCats plugin when not using nix
+---It will help prevent you from running into indexing errors without a nixCats plugin from nix.
+---If you loaded the config via nix, it does nothing
+---non_nix_value defaults to true if not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
   if not M.isNixCats then
@@ -21,29 +25,50 @@ function M.setup(v)
     else
       nixCats_default_value = true
     end
-    -- if not in nix, just make it return a boolean
-    require('_G').nixCats = function(_) return nixCats_default_value end
-    -- and define some stuff for the nixCats plugin
-    -- to prevent indexing errors and provide some values
+    local mk_with_meta = function (tbl)
+      return setmetatable(tbl, {
+        __call = function(_, attrpath)
+          local strtable = {}
+          if type(attrpath) == "table" then
+              strtable = attrpath
+          elseif type(attrpath) == "string" then
+              for key in attrpath:gmatch("([^%.]+)") do
+                  table.insert(strtable, key)
+              end
+          else
+              print("function requires a table of strings or a dot separated string")
+              return
+          end
+          return vim.tbl_get(tbl, unpack(strtable));
+        end
+      })
+    end
     package.preload['nixCats'] = function ()
-      return {
-        cats = {},
-        pawsible = {
-          allPlugins = {
-            start = {},
-            opt = {},
-            ts_grammar_path = nil,
-          },
-        },
-        settings = {
+      local ncsub = {
+        get = function(_) return nixCats_default_value end,
+        cats = mk_with_meta({
           nixCats_config_location = vim.fn.stdpath('config'),
           configDirName = os.getenv("NVIM_APPNAME") or "nvim",
           wrapRc = false,
-        },
+        }),
+        settings = mk_with_meta({
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        }),
+        petShop = mk_with_meta({}),
+        pawsible = mk_with_meta({
+          allPlugins = {
+            start = {},
+            opt = {},
+          },
+        }),
         configDir = vim.fn.stdpath('config'),
         packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
       }
+      return setmetatable(ncsub, {__call = function(_, cat) return ncsub.get(cat) end})
     end
+    _G.nixCats = require('nixCats')
   end
 end
 

--- a/templates/luaUtils/lua/nixCatsUtils/init.lua
+++ b/templates/luaUtils/lua/nixCatsUtils/init.lua
@@ -3,6 +3,7 @@ local M = {}
 -- This directory is the luaUtils template.
 -- the other 3 files are intended to be independent, but may depend on this one.
 -- You will likely want at least something in this one,
+-- and if you use lze or lz.n you should check out lzUtils.lua
 -- but unless you use lazy.nvm or want to use pckr or rocks when not on nix, you wont need the other 2
 
 ---@type boolean
@@ -11,7 +12,10 @@ M.isNixCats = vim.g[ [[nixCats-special-rtp-entry-nixCats]] ] ~= nil
 ---@class nixCatsSetupOpts
 ---@field non_nix_value boolean|nil
 
----defaults to true if non_nix_value is not provided or is not a boolean.
+---This function will setup a mock nixCats plugin when not using nix
+---It will help prevent you from running into indexing errors without a nixCats plugin from nix.
+---If you loaded the config via nix, it does nothing
+---non_nix_value defaults to true if not provided or is not a boolean.
 ---@param v nixCatsSetupOpts
 function M.setup(v)
   if not M.isNixCats then
@@ -21,29 +25,50 @@ function M.setup(v)
     else
       nixCats_default_value = true
     end
-    -- if not in nix, just make it return a boolean
-    require('_G').nixCats = function(_) return nixCats_default_value end
-    -- and define some stuff for the nixCats plugin
-    -- to prevent indexing errors and provide some values
+    local mk_with_meta = function (tbl)
+      return setmetatable(tbl, {
+        __call = function(_, attrpath)
+          local strtable = {}
+          if type(attrpath) == "table" then
+              strtable = attrpath
+          elseif type(attrpath) == "string" then
+              for key in attrpath:gmatch("([^%.]+)") do
+                  table.insert(strtable, key)
+              end
+          else
+              print("function requires a table of strings or a dot separated string")
+              return
+          end
+          return vim.tbl_get(tbl, unpack(strtable));
+        end
+      })
+    end
     package.preload['nixCats'] = function ()
-      return {
-        cats = {},
-        pawsible = {
-          allPlugins = {
-            start = {},
-            opt = {},
-            ts_grammar_path = nil,
-          },
-        },
-        settings = {
+      local ncsub = {
+        get = function(_) return nixCats_default_value end,
+        cats = mk_with_meta({
           nixCats_config_location = vim.fn.stdpath('config'),
           configDirName = os.getenv("NVIM_APPNAME") or "nvim",
           wrapRc = false,
-        },
+        }),
+        settings = mk_with_meta({
+          nixCats_config_location = vim.fn.stdpath('config'),
+          configDirName = os.getenv("NVIM_APPNAME") or "nvim",
+          wrapRc = false,
+        }),
+        petShop = mk_with_meta({}),
+        pawsible = mk_with_meta({
+          allPlugins = {
+            start = {},
+            opt = {},
+          },
+        }),
         configDir = vim.fn.stdpath('config'),
         packageBinPath = os.getenv('NVIM_WRAPPER_PATH_NIX') or vim.v.progpath
       }
+      return setmetatable(ncsub, {__call = function(_, cat) return ncsub.get(cat) end})
     end
+    _G.nixCats = require('nixCats')
   end
 end
 

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license 
 {
   description = ''
     assuming you are at the top level of the repo,

--- a/tests/libT/default.nix
+++ b/tests/libT/default.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub 
+# Licensed under the MIT license
 {
   inputs
   , utils

--- a/tests/libT/libT.lua
+++ b/tests/libT/libT.lua
@@ -1,3 +1,5 @@
+-- Copyright (c) 2023 BirdeeHub 
+-- Licensed under the MIT license 
 if nixCats('nixCats_test_lib_deps') then
     ---@type table<string, true|string>
     local states = {}

--- a/utils/autoPluginOverlay.nix
+++ b/utils/autoPluginOverlay.nix
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 BirdeeHub
+# Licensed under the MIT license
 # This overlay grabs all the inputs named in the format
 # `plugins-<pluginName>`
 # Once we add this overlay to our nixpkgs, we are able to


### PR DESCRIPTION
Added metatables for nixCats plugin

require('nixCats')(cat) now does the same thing as the nixCats(cat) global

nixCats global now also has the other items from the require('nixCats') module

nixCats.settings nixCats.pawsible nixCats.cats nixCats.petShop now can also be called as functions

They take the attrpath as an argument either as table or dot separated string, and return `vim.tbl_get` of the value