### PR TITLE
awaiting github.com/NixOS/nixpkgs/pull/344849

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -43,6 +43,7 @@ let
     suffix-path = false;
     suffix-LD = false;
     disablePythonSafePath = false;
+    collate_grammars = false;
   } // (thisPackage.settings or {});
 
   final_cat_defs_set = ({
@@ -258,8 +259,7 @@ import ./wrapNeovim.nix {
   inherit pkgs;
   neovim-unwrapped = myNeovimUnwrapped;
   inherit extraMakeWrapperArgs nixCats preWrapperShellCode customRC;
-  inherit (settings) vimAlias viAlias withRuby withPerl extraName withNodeJs aliases gem_path;
-  collate_grammars = true;
+  inherit (settings) vimAlias viAlias withRuby withPerl extraName withNodeJs aliases gem_path collate_grammars;
   pluginsOG.myVimPackage = {
     inherit start opt;
   };

--- a/builder/vim-pack-dir.nix
+++ b/builder/vim-pack-dir.nix
@@ -104,14 +104,6 @@ nixCats: packages: let
     ts_grammar_plugin_combined = symlinkJoin {
       name = "vimplugin-treesitter-grammar-ALL-INCLUDED";
       paths = map (e: e.outPath) collected_grammars;
-      # TODO:
-      # https://github.com/NixOS/nixpkgs/pull/344849
-      # when this PR is merged, you can delete this to fix grammars not in nvim-treesitter core.
-      # This was added as a fix for errors introduced.
-      # when you do so, you should finish making collate_grammars into a setting.
-      postBuild = ''
-        rm -rf $out/queries
-      '';
     };
 
     packdirGrammar = [

--- a/nixCatsHelp/nixCats_format.txt
+++ b/nixCatsHelp/nixCats_format.txt
@@ -653,6 +653,14 @@ These are the defaults:
       # causes sharedLibraries to be added to the END of
       # LD_LIBRARY_PATH instead of the start
 
+      # whether to group up treesitter grammars into a single directory,
+      # or leave them as separate plugins.
+      # Some users report a startup performance increase from doing this.
+      # Works only on grammars that have been passed through
+      # pkgs.neovimUtils.grammarToPlugin
+      # or pkgs.vimPlugins.nvim-treesitter.withPlugins
+      collate_grammars = false;
+
       # unsets PYTHONSAFEPATH variable.
       # Can cause issues with reproducibility,
       # can fix some stuff


### PR DESCRIPTION
Add collate_grammars setting, default to false. Can increase startup performance slightly on some systems. Groups all nvim-treesitter grammars into 1 dir on the packpath.

If this gives you treesitter bugs, its because I stopped deleting all the queries to cover up underlying issues in nixpkgs. Update your nvim's nixpkgs input, its fixed now.

https://nixpk.gs/pr-tracker.html?pr=344849