### PR TITLE
Standardise capitalisation and improve formatting.

### DIFF
--- a/nixCatsHelp/README.md
+++ b/nixCatsHelp/README.md
@@ -1,5 +1,5 @@
 These files look nicer in nvim with `:h nixCats.*`
 
-See these files rendered into html exactly
+See these files rendered into HTML exactly
 as they would appear on the page at
-[nixcats.org](https://nixcats.org/TOC.html)
+[nixcats.org](https://nixcats.org/TOC.html).

--- a/nixCatsHelp/nixCats_format.txt
+++ b/nixCatsHelp/nixCats_format.txt
@@ -1,13 +1,13 @@
 =======================================================================================
 Flake Help                                                      *nixCats.flake*
 
-A Lua-natic's neovim flake, with extra cats! nixCats!
+A Lua-natic's Neovim flake, with extra cats! nixCats!
 
 This is the documentation for the flake itself.
-This flake uses nix for importing plugins, lsps, dependencies, and more,
-in place of usual nvim package managers such as packer, lazy or mason.
+This flake uses Nix for importing plugins, LSPs, dependencies, and more,
+in place of usual nvim package managers such as packer, lazy or Mason.
 
-Everything else is done in a regular lua config style.
+Everything else is done in a regular Lua config style.
 Download in flake.nix and then, simply pretend the root of the flake 
 is the root of your Lua config. 
 
@@ -15,9 +15,9 @@ is the root of your Lua config.
 AN IMPORTANT NOTE:
 
 <1> When editing the files within the flake directory,
-nix will not package a new file if it isn't staged in git.
+Nix will not package a new file if it isn't staged in git.
 run git add before rebuilding it whenever adding a new file.
-Using wrapRc = true would mean this also applies to lua files.
+Using `wrapRc = true` would mean this also applies to Lua files.
 Only tracked files will recieve their updates when
 rebuilt without git add being ran first. New files need to be added.
 *******************************************************
@@ -28,15 +28,15 @@ the flake in your Lua, see:
 :help |nixCats|
 
 `stdpath('config')` will still point to `~/.config/<configDirName>`.
-But your lua config will be in the store.
-This is ok, because most of the reason for a plugin to use
+But your Lua config will be in the store.
+This is okay, because most of the reason for a plugin to use
 it would be to write to it, and we cant write to store paths anyway. 
 You could use `require('nixCats').configDir`,
 or `nixCats('nixCats_config_location')`
 to get current config directory for your uses, if ever necessary.
 It will be present and correct regardless of settings.
 
-However if you did not use nix at all and did not run the setup
+However if you did not use Nix at all and did not run the setup
 function, of course the nixCats plugin wont be there to ask.
 
 The setup function from `require('nixCatsUtils').setup`
@@ -60,16 +60,16 @@ you may use this format to import them, replacing the fields marked with <>
 <
 More info on flake url syntax at:
 https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#examples
-You may also use this syntax to pin the version of a plugin regardless of if
-you ran nix flake update or not.
+You may also use this syntax to pin the version of a plugin regardless of whether
+you ran `nix flake update` or not.
 You may choose the directory, branch, commit, tag, or even directory
 imported.
 
 All inputs named in the `plugins-<pluginName>` format will be added to pkgs
 at `pkgs.neovimPlugins.<pluginName>` for you to add to your configuration.
 
-If the plugin has a dot `.` character in it's name, you should name it something else.
-Because . is not a valid character in an identifier in nix.
+If the plugin has a dot `.` character in it's name, you should name it something else
+because . is not a valid character in an identifier in Nix.
 
 The name here only affects the filename of the overall plugin, and should
 only affect things like vim.cmd("packadd <filename>") that refer to
@@ -82,10 +82,10 @@ dot in their name, you may
 swap the call to `(utils.standardPluginOverlay inputs)`
 with `(utils.sanitizedPluginOverlay inputs)`
 and then `plugins-plugin.name` would become `pkgs.neovimPlugins.plugin-name`
-but neovim would see it as `vim.cmd("packadd plugin.name")` still
+but Neovim would see it as `vim.cmd("packadd plugin.name")` still
 
 If they have a build step or are not a plugin, 
-i.e. an lsp, or if they are a plugin from a flake,
+i.e. an LSP, or if they are a plugin from a flake,
 dont name them in that format.
 If they are a plugin from a flake, they can be added directly,
 or they may be added as an overlay if offered.
@@ -139,17 +139,20 @@ the utils.eachSystem function, and thus we can export it
 without having to include a system variable when we import it somewhere else.
 
 We also define our luaPath, which is the path to be loaded into the store as
-your new neovim config directory. (see :help |'rtp'| for the directories
+your new Neovim config directory. (see :help |'rtp'| for the directories
 available for you to use!)
 
 We also define our extra_pkg_config, which is used when initializing the
-nixpkgs instance that will build your neovim! Its the same one from
-pkgs = import nixpkgs { inherit system; overlays = []; config = {}; }
+nixpkgs instance that will build your Neovim! It's the same one from
+>nix
+  pkgs = import nixpkgs { inherit system; overlays = []; config = {}; }
+<
+That is,
 >nix
   outputs = { self, nixpkgs, ... }@inputs: let
     # In the templates, this is inherit (inputs.nixCats) utils;
     inherit (inputs.nixCats) utils;
-    # path the the store path to be loaded as neovim config directory
+    # path the the store path to be loaded as Neovim config directory
     luaPath = "${./.}";
     # used when initializing the nixpkgs instance
     extra_pkg_config = {
@@ -191,7 +194,7 @@ even when importing overlays from improperly formed flakes.
 
 Managing the system variable in combination with overlays
 can be one of the hardest parts of flake usage.
-This flake resolves our pkgs instance for neovim itself to help with this,
+This flake resolves our pkgs instance for Neovim itself to help with this,
 and takes care of passing the correct pkgs instance
 to the categoryDefinitions for use in defining your plugins.
 
@@ -281,10 +284,10 @@ These are the things you can return:
   categoryDefinitions = { pkgs, settings, categories, extra, name, mkNvimPlugin, ... }@packageDef: {
 <
 <lspsAndRuntimeDeps>
-  a flexible set of categories, each containing LSP's or 
+  a flexible set of categories, each containing LSPs or
   other internal runtime dependencies such as ctags or debuggers
-  these are available to the PATH while within the neovim program.
-  this includes the neovim terminal.
+  these are available to the PATH while within the Neovim program.
+  this includes the Neovim terminal.
 
 <startupPlugins>
   a flexible set of categories, each containing startup plugins.
@@ -316,9 +319,9 @@ github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper
 
 <extraPython3Packages> 
   a flexible set of categories, each containing FUNCTIONS
-  that return lists of python packages.
+  that return lists of Python packages.
   These functions are the same thing that you would pass to python.withPackages.
-  You may get the path to this python environment in your lua config via
+  You may get the path to this Python environment in your Lua config via
   vim.g.python3_host_prog
   or run from nvim terminal via :!<packagename>-python3
 
@@ -331,22 +334,22 @@ github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper
   USING THIS OPTION WILL CAUSE NVIM TO BUILD FROM SOURCE.
 
 <optionalLuaPreInit>
-  a flexible set of categories, each containing a lua string
+  a flexible set of categories, each containing a Lua string
   that will be ran before sourcing your init.lua
   Yes it can access nixCats.
-  It is not the recommended way to create lua for this flake, 
+  It is not the recommended way to create Lua for this flake,
   but it may be useful in editing flake imports 
   of other already configured setups following the nixCats format.
 <optionalLuaAdditions>
-  a flexible set of categories, each containing a lua string
+  a flexible set of categories, each containing a Lua string
   that will be ran after sourcing your init.lua
   Yes it can access nixCats.
-  It is not the recommended way to create lua for this flake, 
+  It is not the recommended way to create Lua for this flake,
   but it may be useful in editing flake imports 
   of other already configured setups following the nixCats format.
 <bashBeforeWrapper>
-  a flexible set of categories, each containing arbitrary bash code
-  to run before the wrapper starts within the wrapper's bash environment.
+  a flexible set of categories, each containing arbitrary Bash code
+  to run before the wrapper starts within the wrapper's Bash environment.
   CAUTION: only use this if you know what you are doing and why you need
   to do it. Whenever possible, use extraWrapperArgs instead.
 <extraCats>
@@ -476,7 +479,7 @@ This applies in many situations. Take this one for example.
       ];
     };
 
-< If you were to put the following in your packageDefinitions: >nix
+< If you were to put the following in your `packageDefinitions`: >nix
     neonixdev.nix-doc = true;
 <
 neodev-nvim and neoconf-nvim would still be included.
@@ -487,12 +490,12 @@ Sometimes it is not and a list of packages would be better suited.
 
 This leads us to our second way to make a default value:
 
-#2 Explicit: using extraCats section of categoryDefinitions.
+#2 Explicit: using `extraCats` section of `categoryDefinitions`.
 
-extraCats section of categoryDefinitions contains categories of attribute
+The `extraCats` section of `categoryDefinitions` contains categories of attribute
 paths. If that category is defined, the categories specified by the attribute
 paths will also be enabled. This means you could make it so that if you
-included the go category, it could then enable debug.go and lsp.go for you.
+included the go category, it could then enable `debug.go` and `lsp.go` for you.
 But in addition to that, it can be combined with the implicit form of creating
 default values above in an interesting way.
 >nix
@@ -578,7 +581,7 @@ an example package definition:
         neonixdev = true;
 
         # this does not have an associated category of plugins, 
-        # but lua can still check for it
+        # but Lua can still check for it
         lspDebugMode = false;
 
         # you could also pass something else and it calls 
@@ -587,7 +590,7 @@ an example package definition:
         # maybe you need to pass a port or path in or something idk.
         # you could :lua =nixCats("theBestCat")
         # this nixCats("path.to.val") is the main category check function
-        # and it is built to mirror the nix category scheme as much as possible
+        # and it is built to mirror the Nix category scheme as much as possible
       };
       extra = {
         there_is = "also";
@@ -602,8 +605,8 @@ an example package definition:
     };
   };
 <
-You can use the nixCats plugin for the set you define here in your lua
-It returns a lua table of the same format.
+You can use the nixCats plugin for the set you define here in your Lua
+It returns a Lua table of the same format.
 
 see :help |nixCats|
 
@@ -633,10 +636,10 @@ These are the defaults:
       withNodeJs = false;
       withPerl = false;
 
-      # do you want to package the lua from this flake in the store?
+      # do you want to package the Lua from this flake in the store?
       # or would you rather it just read it in your .config/<configDirName>?
       # nixCats and this help will work either way.
-      # packages with wrapRc = false are for quick changes to lua.
+      # packages with wrapRc = false are for quick changes to Lua.
       # it is not for being ran from anywhere via nix run, because the config
       # was not wrapped with the program.
       wrapRc = true;
@@ -651,23 +654,23 @@ These are the defaults:
 
       # Only active when wrapRc = false, this option allows you to specify
       # an absolute path to the unwrapped config directory.
-      # This is not a nix path. This is the unwrapped config directory.
+      # This is not a Nix path. This is the unwrapped config directory.
       # This means you are going to need to make
       # sure that it points the right place on the current machine.
       unwrappedCfgPath = null;
       # Will not change anything other than config directory, configDirName
       # is still needed for .local/share or .cache and the like
 
-      # use this to pin a specific neovim version.
-      # This one will specify the base neovim derivation to use.
+      # use this to pin a specific Neovim version.
+      # This one will specify the base Neovim derivation to use.
       neovim-unwrapped = null;
-      # This one will just override the src value of the neovim in nixpkgs
+      # This one will just override the src value of the Neovim in nixpkgs
       # import it in flake inputs with flake = false,
-      # It will also obviously cause neovim to build from source.
+      # It will also obviously cause Neovim to build from source.
       nvimSRC = null;
 
       # These 2 options are useful for when you want to allow your dev shells
-      # to override things such as lsps and shared libraries that you have
+      # to override things such as LSPs and shared libraries that you have
       # already in your configuration.
       suffix-path = false;
       # causes lspsAndDeps to be added to the END of
@@ -692,13 +695,13 @@ These are the defaults:
 
       # optional, specify custom store path gemdir
       # must contain a gemset.nix like one generated by bundix
-      # must contain the neovim gem
+      # must contain the Neovim gem
       # for further info, see
       # https://github.com/NixOS/nixpkgs/tree/74ad6cb1d2b14edb4ad1fffc0791e94910c61453/pkgs/applications/editors/neovim/ruby_provider
       # https://github.com/BirdeeHub/neovim_ruby_updater
       gem_path = null;
       # If you are using neovim-unwrapped from nixpkgs itself,
-      # there is a good chance your neovim
+      # there is a good chance your Neovim
       # will not be able to find it regardless of settings.
       # thus withRuby and gem_path options may not work
       # It works great using https://github.com/nix-community/neovim-nightly-overlay
@@ -714,34 +717,34 @@ These are the defaults:
 
 QUICK TIP: wrapRc
 
-The wrapRc option is very useful for testing lua changes.
-It removes the need to stage and rebuild to see your lua changes reflected.
-You will still need to rebuild when making changes to nix regardless of the
-value of wrapRc
+The `wrapRc` option is very useful for testing Lua changes.
+It removes the need to stage and rebuild to see your Lua changes reflected.
+You will still need to rebuild when making changes to Nix regardless of the
+value of `wrapRc`.
 
-However it also means that the lua isn't going run if it isn't in the right
-folder, i.e. when installed and ran from github with nix run
+However it also means that the Lua isn't going run if it isn't in the right
+folder, i.e. when installed and run from GitHub with `nix run`.
 
-If the lua is not in `vim.fn.stdpath('config')`, wrapRc = false will not work.
-By default this is `~/.config/nvim` on linux systems, although we can
-change `nvim` to whatever we wish via the configDirName setting.
+If the Lua is not in `vim.fn.stdpath('config')`, `wrapRc = false` will not work.
+By default this is `~/.config/nvim` on Linux systems, although we can
+change `nvim` to whatever we wish via the `configDirName` setting.
 
 Alternatively, you can set the `unwrappedCfgPath` option to allow the
 configuration to be set to an absolute path. You still may want to set
-the configDirName option anyway to change the data directories,
+the `configDirName` option anyway to change the data directories,
 or explicitly keep it the same on both so that they share stuff like auths.
 
 The most convenient way to use this is the following:
-Make a second identical packageDefinition, but with wrapRc disabled.
+Make a second identical `packageDefinition`, but with `wrapRc` disabled.
 Then install both the wrapped one and unwrapped one with different aliases.
-When you want to hack in lua, use unwrapped! When you're done, just rebuild
+When you want to hack in Lua, use unwrapped! When you're done, just rebuild
 and go back to the wrapped one.
 
-The templates/example/flake.nix file from the example config template
+The `templates/example/flake.nix` file from the example config template
 has an example of this with nixCats and regularCats.
 
-Then, when testing lua changes, you run the other package and have a vanilla
-neovim experience, only rebuilding when you install new packages.
+Then, when testing Lua changes, you run the other package and have a vanilla
+Neovim experience, only rebuilding when you install new packages.
 
 When you are satisfied, simply rebuild and go back to using the main package,
 as it was the same except for the single option!
@@ -750,26 +753,26 @@ as it was the same except for the single option!
 Neovim Builder Creation:                        *nixCats.flake.outputs.builder*
 
 Now we define our builder function.
-We inherit utils.baseBuilder which is
-a function that takes 5 arguments. It is defined in ./builder
-Right now we are going to call it with just the first 4 of them. This will
+We inherit `utils.baseBuilder` which is
+a function that takes five arguments. It is defined in `./builder`.
+Right now we are going to call it with just the first four arguments. This will
 leave us with a function that takes 1 argument.
-That argument is the name of the neovim package to be packaged.
+That argument is the name of the Neovim package to be packaged.
 
-1. The path to the lua to include (in the flake, we use the self variable to get
-     this path and wrap the lua when wrapRc = true)
+1. The path to the Lua to include (in the flake, we use the self variable to get
+     this path and wrap the Lua when `wrapRc = true`)
 
 2. A set containing:
-  The dependencyOverlays set or list,
+  The `dependencyOverlays` set or list,
   extra_pkg_config, nixpkgs, nixCats_passthru, and system so it can
   resolve pkgs and pass it where it needs to go.
 
 3. our function that takes an individual package definition
      and returns a set of categoryDefinitions.
 
-4. our set of packageDefinitions see: |nixCats.flake.outputs.packageDefinitions|
+4. our set of `packageDefinitions` see: |nixCats.flake.outputs.packageDefinitions|
 
-It is now a function that takes a name, and returns your chosen neovim package.
+It is now a function that takes a name, and returns your chosen Neovim package.
 >nix
   # It requires the system variable to build a package.
   utils.eachSystem nixpkgs.lib.platforms.all (system: let
@@ -790,10 +793,10 @@ If you use it wrong, you will most likely get this error message:
 >nix
   # -------------------------------------------------------- #
 
-  # the path to your ~/.config/nvim replacement within your nix config.
+  # the path to your ~/.config/nvim replacement within your Nix config.
   luaPath: # <-- must be a store path
 
-  { # set of items for building the pkgs that builds your neovim
+  { # set of items for building the pkgs that builds your Neovim
 
     , nixpkgs # <-- required
     , system # <-- required
@@ -849,7 +852,7 @@ They look something like this:
     defaultPackage = nixCatsBuilder defaultPackageName;
 
     # this is just for using utils in the following section such as pkgs.mkShell
-    # The one used to build neovim is resolved inside the builder
+    # The one used to build Neovim is resolved inside the builder
     # and is passed to our categoryDefinitions and packageDefinitions
     pkgs = import nixpkgs { inherit system; };
     # as you can see, "resolve pkgs" does not mean anything fancy.
@@ -894,13 +897,13 @@ They look something like this:
       # and also our categoryDefinitions
     } categoryDefinitions packageDefinitions defaultPackageName;
 
-    # we export a nixos module to allow configuration from configuration.nix
+    # we export a NixOS module to allow configuration from configuration.nix
     # allows you to either inherit values from your main flake, or start fresh
     nixosModules.default = utils.mkNixosModules {
       inherit dependencyOverlays luaPath defaultPackageName
         categoryDefinitions packageDefinitions nixpkgs;
     };
-    # and the same for home manager
+    # and the same for Home Manager
     homeModule = utils.mkHomeModules {
       inherit dependencyOverlays luaPath defaultPackageName
         categoryDefinitions packageDefinitions nixpkgs;
@@ -972,14 +975,14 @@ If invalid type or system, returns an empty list
     inherit nixpkgs dependencyOverlays
       categoryDefinitions packageDefinitions extra_pkg_config;
 };
-Will create a nixos module that you can import in configuration.nix
-If you do not have a luaPath, you may pass it a keepLua builder
-See :help |nixCats.flake.outputs.exports.mkNixosModules|
-The packages also export a module with defaultPackageName
+Will create a NixOS module that you can import in `configuration.nix`.
+If you do not have a `luaPath`, you may pass it a `keepLua` builder
+See :help |nixCats.flake.outputs.exports.mkNixosModules|.
+The packages also export a module with `defaultPackageName1`
 set to THEIR package name via their passthru variable using this function.
 
 <mkHomeModules>
-The same as mkNixosModules above, but for home manager.
+The same as mkNixosModules above, but for Home Manager.
 
 <mkAllWithDefault> package:
 makes each package in the packageDefinitions this package was made from
@@ -1063,11 +1066,11 @@ It is the same thing as `nixpkgs.lib.genAttrs`, renamed so that people know
 how to use it.
 
                                   *nixCats.flake.outputs.utils.n2l*
-<n2l> This is the nix to lua library nixCats
-uses to create the nixCats lua plugin
+<n2l> This is the Nix to Lua library nixCats
+uses to create the nixCats Lua plugin
 You may wish to use some functions from it.
 
-It contains <toLua> and <prettyLua> and <uglyLua> which convert nix to lua.
+It contains <toLua> and <prettyLua> and <uglyLua> which convert Nix to Lua.
 
 it contains a <member> function to determine if a value is a special "inline lua" type
 it contains a <typeof> function to determine which special "inline lua" type it is
@@ -1078,11 +1081,11 @@ But of much more interest to you is the types you may declare.
 
 Everything being passed through settings, categories, and extra in packageDefinitions
 will be properly escaped. But this also means that
-you cannot write any lua code there.
+you cannot write any Lua code there.
 
 Luckily, we have some types we can declare that will allow you to do this.
 
-To declare that an item is a lua value rather than a hard coded one,
+To declare that an item is a Lua value rather than a hard coded one,
 you may choose one of these types. To do this, call its constructor!
 
 for example, `types.inline-unsafe` has 1 field, `body`.
@@ -1104,7 +1107,7 @@ These are all the types, each one has an associated `mk`
 function to create a value of that type,
 which accepts the fields listed here, defined with default values.
 >nix
-  # creates an inline lua value in a way that cant break the table
+  # creates an inline Lua value in a way that cant break the table
   inline-safe = {
     default = (v: if v ? body then v else { body = v; });
     fields = { body = "nil"; };
@@ -1131,7 +1134,7 @@ which accepts the fields listed here, defined with default values.
   with-meta = {
     fields = {
       table = {}; # <- the table you are adding
-      meta = {}; # <- the metatable you want to add to it (in nix)
+      meta = {}; # <- the metatable you want to add to it (in Nix)
       newtable = null; # <- if you want to specify a different first arg to setmetatable
       tablevar = "tbl_in"; # <- varname to refer to the table, to avoid translating multiple times
     };
@@ -1171,13 +1174,13 @@ Some more useage examples:
   in {
     table = {
       this = "is a test table";
-      inatesttable = "that will be translated to a lua table with a metatable";
+      inatesttable = "that will be translated to a Lua table with a metatable";
     };
     # to avoid translating the table multiple times,
-    # define a variable name for it in lua. Defaults to "tbl_in"
+    # define a variable name for it in Lua. Defaults to "tbl_in"
     inherit tablevar;
     meta = {
-      # __call in lua lets us also call it like a function
+      # __call in Lua lets us also call it like a function
       __call = utils.n2l.types.function-unsafe.mk {
         args = [ "self" "..." ];
         body = ''
@@ -1193,36 +1196,37 @@ Some more useage examples:
   });
 <
 ---------------------------------------------------------------------------------------
-Nix OS Module                     *nixCats.flake.outputs.exports.mkNixosModules*
+NixOS Module                      *nixCats.flake.outputs.exports.mkNixosModules*
                                   *nixCats.flake.outputs.exports.mkHomeModules*
 
 We create the module by exporting the following in our flake outputs.
-More information on the modules can be found at :h |nixCats.module|
+More information on the modules can be found at :h |nixCats.module|.
+>nix
+  <mkNixosModules> {
+      defaultPackageName = "nixCats";
+      luaPath = "${./.}";
+      inherit nixpkgs dependencyOverlays
+        categoryDefinitions packageDefinitions extra_pkg_config;
+  };
 
-<mkNixosModules> {
-    defaultPackageName = "nixCats";
-    luaPath = "${./.}";
-    inherit nixpkgs dependencyOverlays
-      categoryDefinitions packageDefinitions extra_pkg_config;
-};
-
-<mkHomeModules> {
-    defaultPackageName = "nixCats";
-    luaPath = "${./.}";
-    inherit nixpkgs dependencyOverlays
-      categoryDefinitions packageDefinitions extra_pkg_config;
-};
-
-dependencyOverlays may be dependencyOverlays.${system} = [ list of overlays ];
-or simply dependencyOverlays = [ list of overlays ];
+  <mkHomeModules> {
+      defaultPackageName = "nixCats";
+      luaPath = "${./.}";
+      inherit nixpkgs dependencyOverlays
+        categoryDefinitions packageDefinitions extra_pkg_config;
+  };
+<
+`dependencyOverlays` may be >nix
+  dependencyOverlays.${system} = [ list of overlays ];
+or simply `dependencyOverlays = [ list of overlays ];`.
 
 IMPORTANT
-By default, the module inherits your flake or nixExpressionFlakeOutputs nixpkgs object,
-and its overlays, and everything else.
+By default, the module inherits your flake or `nixExpressionFlakeOutputs nixpkgs object`,
+its overlays, and everything else.
 It will still inherit your system overlays and config set and system value,
 but your system will not inherit overlays added to the nixCats module option.
 
-More information on the modules can be found at :h |nixCats.module|
+More information on the modules can be found at :h |nixCats.module|.
 
 ---------------------------------------------------------------------------------------
 vim:tw=78:ts=8:ft=help:norl:

--- a/nixCatsHelp/nixCats_installation.txt
+++ b/nixCatsHelp/nixCats_installation.txt
@@ -6,8 +6,8 @@ INSTALLATION:                                                   *nixCats.install
   # then launch with
   nixCats
 <
-Now that you have access to the help and a nix lsp, to get started,
-first exit neovim. (but not the nix shell!)
+Now that you have access to the help and a Nix LSP, to get started,
+first exit Neovim. (but not the Nix shell!)
 
 In a terminal, navigate to your nvim directory and
 run your choice of the following commands (don't worry! It doesnt overwrite):
@@ -20,15 +20,15 @@ run your choice of the following commands (don't worry! It doesnt overwrite):
   # to recieve all normal flake outputs
   nix flake init -t github:BirdeeHub/nixCats-nvim#nixExpressionFlakeOutputs
 
-  # for utilities for functionality without nix
+  # for utilities for functionality without Nix
   # added at lua/nixCatsUtils also run:
   nix flake init -t github:BirdeeHub/nixCats-nvim#luaUtils
-  # contains things like "is this nix?" "do this if not nix, else do that"
+  # contains things like "is this Nix?" "do this if not Nix, else do that"
   # needs to be in your config at lua/nixCatsUtils,
-  # because if you dont use nix to load neovim,
-  # nixCats (obviously) can't provide you with anything from nix!
+  # because if you dont use Nix to load Neovim,
+  # nixCats (obviously) can't provide you with anything from Nix!
 
-  # If using zsh with extra regexing, be sure to escape the #
+  # If using Zsh with extra regexing, be sure to escape the #
 <
 This will create an empty version of flake.nix (or default.nix) for you to fill in.
 
@@ -37,56 +37,62 @@ you should instead use the following template:
 >bash
   nix flake init -t github:BirdeeHub/nixCats-nvim#example
 <
-If you added the luaUtils template, you should also have that at lua/nixCatsUtils
+If you added the `luaUtils` template, you should also have that at `lua/nixCatsUtils`
 
-Re-enter the nixCats nvim version by typing nixCats . and take a look!
+Re-enter the nixCats nvim version by typing `nixCats .` and take a look!
 Reference the `:help nixCats` docs and nixCats-nvim itself as a guide for importing your setup.
 
 You add plugins to the flake.nix, call whatever setup function is required by the plugin,
-and use lspconfig to set up lsps. You may optionally choose to set up a plugin
-only when that particular category is enabled in the current package
+and use lspconfig to set up LSPs. You may optionally choose to set up a plugin
+only when that particular category is enabled in the current package.
 <
-It is a similar process to migrating to a new neovim plugin manager.
+It is a similar process to migrating to a new Neovim plugin manager.
 
 Use a template, and migrate your plugins into the flake.nix file provided.
 
-Then configure in lua with the configuration options provided by the plugin.
+Then configure in Lua with the configuration options provided by the plugin.
 
 It is suggested to start with the default template so that you can mess around with it in
 a separate repository/directory,
-and easily use nix repl to see what it exports.
+and easily use Nix REPL to see what it exports.
 Just use `nix repl` in the directory, `:lf .` and type `outputs.` and
 autocomplete to see the exported items!
 
-Then move to the nixExpressionFlakeOutputs template to
-integrate it with your main nix config when you are happy with it!
+Then move to the `nixExpressionFlakeOutputs` template to
+integrate it with your main Nix config when you are happy with it!
 
-This is because the nixExpressionFlakeOutputs template
+This is because the `nixExpressionFlakeOutputs` template
 is simply the outputs function of the default template. You then move the
 inputs to your main system inputs, and retrieve all the normal flake outputs
-with yournvim = import ./the/dir/with/template { inherit inputs; };
-You can then install them with yournvim.packages.${system}.nvimpackagename,
+with
+>nix
+  yournvim = import ./the/dir/with/template { inherit inputs; };
+<
+You can then install them with
+>nix
+  .packages.${system}.nvimpackagename,
+<
 use the modules they export to modify them further before installing them,
 install them via overlay, export them from your system flake so you can still
-access them from anywhere via nix run, etc...
+access them from anywhere via `nix run` etc.
 
 Use the help and the example config in nixCats-nvim itself that you just ran as an example.
 The help will still be accessible in your version of the editor.
 
-When you have your plugins added, you can build it using nix build and it
-will build to a result directory, or nix profile install to install it to your
+When you have your plugins added, you can build it using `nix build` and it
+will build to a result directory, or `nix profile install` to install it to your
 profile. Make sure you run `git add .` first as anything not staged will not
-be added to the store and thus not be findable by either nix or neovim.
-See nix documentation on how to use these commands further at:
-[the nix command reference manual]
+be added to the store and thus not be findable by either Nix or Neovim.
+See Nix documentation on how to use these commands further at:
+[the Nix command reference manual]
 (https://nixos.org/manual/nix/stable/command-ref/new-cli/nix)
 
 When you have a working version, you can begin to explore the many
-options made available for importing your new nix neovim configuration
-into a nix system or home manager configuration.
+options made available for importing your new Nix Neovim configuration
+into a Nix system or Home Manager configuration.
 There are MANY, thanks to the virtues of the category scheme of this flake.
 
-It is made to be customized into your own portable nix neovim distribution 
+It is made to be customized into your own portable Nix Neovim distribution
 with as many options as you wish, while requiring you to leave the normal
 nvim configuration scheme as little as possible.
 
@@ -95,7 +101,7 @@ How it works in 100 lines:                                  *nixCats.overview*
 
 <tip> For the following 100 lines, it is most effective to cross reference with a template!
 
-First choose a path for luaPath as your new neovim directory to be loaded into
+First choose a path for `luaPath` as your new Neovim directory to be loaded into
 the store.
 
 Then in `categoryDefinitions`:
@@ -103,7 +109,7 @@ You have a SET to add LISTS of plugins to the packpath (one for both
 pack/*/start and pack/*/opt), a SET to add LISTS of things to add to the path,
 a set to add lists of shared libraries,
 a set of lists to add... pretty much anything.
-Full list of these sets is at :h |nixCats.flake.outputs.categories|
+Full list of these sets is at :h |nixCats.flake.outputs.categories|.
 
 Those lists are in sets, and thus have names.
 
@@ -125,7 +131,7 @@ If, from your `categoryDefintions`, you returned:
   };
 <
 In your `packageDefintions`, if you wanted to include it in a package named
-myCoolNeovimPackage, launched with either myCoolNeovimPackage or vi,
+myCoolNeovimPackage, launched with either `myCoolNeovimPackage` or `vi`,
 you could have:
 >nix
     # see :help nixCats.flake.outputs.packageDefinitions
@@ -144,61 +150,61 @@ you could have:
     };
     defaultPackageName = "myCoolNeovimPackage";
 <
-They also return a set of settings, for the full list see :h |nixCats.flake.outputs.settings|
+They also return a set of settings, for the full list see :h |nixCats.flake.outputs.settings|.
 
 Then, a package is exported and built based on that using the nixCats builder
 function, and various flake exports such as modules based on your config
 are made using utility functions provided.
-The templates take care of that part for you, just add stuff to lists.
+The templates take care of that part for you: just add stuff to lists.
 
 But the cool part. That set of settings and categories is translated verbatim
-from a nix set to a lua table, and put into a plugin that returns it.
-It also passes the full set of plugins included via nix and their store paths
-in the same manner. This gives full transparency to your neovim of everything
-in nix. Passing extra info is rarely necessary outside of including categories
-and setting settings, but it can be useful, and anything other than nix
+from a Nix set to a Lua table, and put into a plugin that returns it.
+It also passes the full set of plugins included via Nix and their store paths
+in the same manner. This gives full transparency to your Neovim of everything
+in Nix. Passing extra info is rarely necessary outside of including categories
+and setting settings, but it can be useful, and anything other than Nix
 functions may be passed. You then have access to the contents of these tables
-anywhere in your neovim, because they are literally a set hardcoded into a
-lua file on your runtimpath.
+anywhere in your Neovim, because they are literally a set hardcoded into a
+Lua file on your runtimepath.
 
 You may use the `:NixCats` user command to view these
 tables for your debugging. There is a global function defined that
 makes checking subcategories easier. Simply call `nixCats('the.category')`!
-It will return the nearest parent category value, but nil if it was a table,
+It will return the nearest parent category value, but `nil` if it was a table,
 because that would mean a different sub category was enabled, but this one was
 not. It is simply a getter function for the table `require('nixCats').cats`
 see :h |nixCats| for more info.
 
-That is what enables full transparency of your nix configuration
-to your neovim! Everything you could have needed to know from nix
+That is what enables full transparency of your Nix configuration
+to your Neovim! Everything you could have needed to know from Nix
 is now easily passed, or already available, through the nixCats plugin!
 
 It has a shorthand for importing plugins that arent on nixpkgs, covered in
 :h |nixCats.flake.inputs| and the templates set up the outputs for you.
-Info about those outputs is detailed in |nixCats.flake.outputs.exports|
+Info about those outputs is detailed in |nixCats.flake.outputs.exports|.
 You can also add overlays accessible to the pkgs object above, and set config
 values for it, how to do that is at the top of the templates, and covered in
-help at :h |nixCats.flake.outputs| and :h |nixCats.flake.outputs.overlays|
+help at :h |nixCats.flake.outputs| and :h |nixCats.flake.outputs.overlays|.
 
-It also has a template containing some lua functions that can allow you
-to adapt your configuration to work without nix. For more info see :h
+It also has a template containing some Lua functions that can allow you
+to adapt your configuration to work without Nix. For more info see :h
 |nixCats.luaUtils| It contains useful functions,
-such as "did nix load neovim" and "if not nix do this, else do that"
+such as "did Nix load Neovim" and "if not Nix do this, else do that"
 It also contains a simple wrapper for lazy.nvim that does the rtp reset
 properly, and then can be used to tell lazy not
 to download stuff in an easy to use fashion.
 
 The goal of the starter templates is so that the usage at the start can be as simple
-as adding plugins to lists and calling `require('theplugin').setup()`
+as adding plugins to lists and calling `require('theplugin').setup()`.
 Most further complexity is optional, and very complex things can be achieved
-with only minor changes in nix, and some `nixCats('something')` calls.
+with only minor changes in Nix, and some `nixCats('something')` calls.
 You can then import the finished package, and reconfigure it again
-without duplication using the override function! see :h |nixCats.overriding|
+without duplication using the override function! see :h |nixCats.overriding|.
 
 ---------------------------------------------------------------------------------------
                                                            *nixCats.templates*
 The templates may also be imported from the utils set
-via `inputs.nixCats.utils.templates`
+via `inputs.nixCats.utils.templates`.
 The following is the set where they are defined.
 
 You may initialize them into the current directory via >bash
@@ -207,32 +213,32 @@ You may initialize them into the current directory via >bash
   {
     default = {
       path = ./fresh;
-      description = "starting point template for making your neovim flake";
+      description = "Starting point template for making your Neovim flake";
     };
     fresh = {
       path = ./fresh;
-      description = "starting point template for making your neovim flake";
+      description = "Starting point template for making your Neovim flake";
     };
     example = {
       path = ./example;
-      description = "an idiomatic nixCats example configuration using lze for lazy loading and paq.nvim for backup when not using nix";
+      description = "An idiomatic nixCats example configuration using lze for lazy loading and paq.nvim for backup when not using Nix.";
     };
     module = {
       path = ./module;
       description = ''
-        starting point for creating a nixCats module for your system and home-manager
+        Starting point for creating a nixCats module for your system and Home Manager.
 
-        contains an example home manager module and an example nixos module in
+        Contains an example Home Manager module and an example NixOS module in
         separate files.
       '';
     };
     nixExpressionFlakeOutputs = {
       path = ./nixExpressionFlakeOutputs;
       description = ''
-        how to import as just the outputs section of the flake, so that you can export
-        its outputs with your system outputs
+        How to import as just the outputs section of the flake, so that you can export
+        its outputs with your system outputs.
 
-        It is best practice to avoid using the system pkgs and its overlays in this method
+        It is best practice to avoid using the system pkgs and its overlays in this method,
         as then you could not output packages for systems not defined in your system flake.
         It creates a new one instead to use, just like the flake template does.
 
@@ -248,23 +254,23 @@ You may initialize them into the current directory via >bash
 
         Equivalent to the default flake template
         or nixExpressionFlakeOutputs except
-        for using overrides
+        for using overrides.
 
-        every nixCats package is a full nixCats-nvim
+        Every nixCats package is a full nixCats-nvim.
       '';
     };
     luaUtils = {
       path = ./luaUtils;
       description = ''
-        A template that includes lua utils for using neovim package managers
-        when your config file is not loaded via nix.
+        A template that includes Lua utils for using Neovim package managers
+        when your config file is not loaded via Nix.
       '';
     };
     kickstart-nvim = {
       path = ./kickstart-nvim;
       description = ''
         The entirety of kickstart.nvim implemented as a nixCats flake.
-        With additional nix lsps for editing the nix part.
+        With additional Nix LSPs for editing the Nix part.
         This is to serve as the tutorial for using the nixCats lazy wrapper.
       '';
     };
@@ -278,21 +284,21 @@ You may initialize them into the current directory via >bash
         In addition, it is also a demonstration of how to export a nixCats configuration
         as an AppImage.
 
-        It is a 2 for 1 example of 2 SEPARATE things one could do.
+        It is a two-for-one example of two SEPARATE things one could do.
       '';
     };
     overlayHub = {
       path = ./overlayHub;
       description = ''
         A template for overlays/default.nix
-        :help nixCats.flake.nixperts.overlays
+        :help nixCats.flake.nixperts.overlays.
       '';
     };
     overlayFile = {
       path = ./overlayfile;
       description = ''
         A template for an empty overlay file defined as described in
-        :help nixCats.flake.nixperts.overlays
+        :help nixCats.flake.nixperts.overlays.
       '';
     };
   }

--- a/nixCatsHelp/nixCats_luaUtils.txt
+++ b/nixCatsHelp/nixCats_luaUtils.txt
@@ -2,22 +2,22 @@
                                                             *nixCats.luaUtils*
 ---------------------------------------------------------------------------------
                                                       *nixCats.luaUtils.intro*
-nixCats has good integration with pckr and other similar neovim package
+nixCats has good integration with pckr and other similar Neovim package
 managers.
 
-Keep in mind they may not work so well on nixos,
-so when you are on nixOS you should load neovim via nix
-(not sure if that part needs stating)
+Keep in mind they may not work so well on NixOS,
+so when you are on NixOS you should load Neovim via Nix
+(not sure if that part needs stating).
 
-to get your lua utils run
+To get your Lua utils, run
 >bash
   nix flake init -t github:BirdeeHub/nixCats-nvim#luaUtils
 <
-ALSO keep in mind, if you are not using nix, you will have to download
-all your non-plugin, non-lsp dependencies manually, and this may suck.
+ALSO keep in mind, if you are not using Nix, you will have to download
+all your non-plugin, non-LSP dependencies manually, and this may suck.
 Therefore, all this stuff about package managers may be of limited utility.
 
-I have written some lua utilities to enable this.
+I have written some Lua utilities to enable this.
 There is a template for them, and you can use the flake init -t
 variable to import the luaUtils template in the root directory of your config
 to add it to your project in the correct place.
@@ -29,20 +29,20 @@ flake. The main init.lua in it contains a `require("nixCatsUtils").setup`
 function, and a `require("nixCatsUtils").isNixCats` variable.
 
 The `require("nixCatsUtils").isNixCats` variable is true if
-you installed neovim via nix, and otherwise it is false.
-This is used to enable package managers only when not loaded via nix.
+you installed Neovim via Nix, and otherwise it is false.
+This is used to enable package managers only when not loaded via Nix.
 
 You run the `setup` function in your init.lua file at the start, and tell it
 what nixCats global command should default to if isNixCats is false.
 The default is true.
 
 IF YOU DO NOT DO THIS SETUP CALL:
-the result will be that, when you load this folder without using nix,
+the result will be that, when you load this folder without using Nix,
 the global nixCats function which you use everywhere
 to check for categories will throw an error.
 This setup function will give it a default value.
-Of course, if you only ever download nvim with nix, this isnt needed.
-But it cant hurt to include anyway.
+Of course, if you only ever download Neovim with Nix, this isn't needed.
+But it can't hurt to include anyway.
 >lua
   vim.g.mapleader = ' '
   vim.g.maplocalleader = ' '
@@ -61,9 +61,9 @@ it also has a few other things that may prove handy
   ---@overload fun(v: any): any|nil
   ---@overload fun(v: any, o: any): any
   require('nixCatsUtils').lazyAdd(v, o)
-  -- if not nix, return the first thing.
-  -- If it is nix, return the second, or nil if not provided.
-  -- used for disabling things like lazy build steps on nix when needed
+  -- If not Nix, return the first thing.
+  -- If it is Nix, return the second, or nil if not provided.
+  -- used for disabling things like lazy build steps on Nix when needed
 
   ---@overload fun(v: string|string[]): boolean
   ---@overload fun(v: string|string[], default: boolean): boolean
@@ -71,22 +71,22 @@ it also has a few other things that may prove handy
 
   -- v will be passed to nixCats function.
   -- If the value fetched by nixCats is nil or false,
-  -- return false, otherwise return true
-  -- if not loaded by nix, return the default value,
+  -- return false, otherwise return true.
+  -- If not loaded by Nix, return the default value,
   -- or fall back on the nixCats default value provided by
-  -- the require("nixCatsUtils").setup function mentioned above
+  -- the require("nixCatsUtils").setup function mentioned above.
 
   ---@param v string|string[]
   ---@param default any
   ---@return any
   require('nixCatsUtils').getCatOrDefault(v, default)
-  ---if nix, return value of nixCats(v) else return default
-  ---Exists to specify a different non_nix_value than the one in setup()
+  -- If Nix, return value of nixCats(v) else return default.
+  -- Exists to specify a different non_nix_value than the one in setup().
 
   ---@type string
   require('nixCatsUtils').packageBinPath
-  ---Useful for things such as vim-startuptime which must reference the wrapper's actual path
-  ---If not using nix, this will simply return vim.v.progpath
+  -- Useful for things such as vim-startuptime which must reference the wrapper's actual path.
+  -- If not using Nix, this will simply return vim.v.progpath.
 <
 ---------------------------------------------------------------------------------
                                                        *nixCats.luaUtils.lazy*
@@ -101,10 +101,10 @@ Use the following command in a new directory and check it out!
   ---@overload fun(nixLazyPath: string|nil, lazySpec: any, opts: table)
   ---@overload fun(nixLazyPath: string|nil, opts: table)
   require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "lazy.nvim" }), lazySpec, opts)
-  -- as long as you call the require('nixCatsUtils').setup function first,
+  -- As long as you call the require('nixCatsUtils').setup function first,
   -- nixCats.pawsible will not throw an error even
-  -- if no nix was used to load your config
-  -- this is covered in the mentioned template
+  -- if no Nix was used to load your config.
+  -- This is covered in the mentioned template.
 <
 The tutorial:
 >nix
@@ -112,7 +112,7 @@ The tutorial:
       path = ./kickstart-nvim;
       description = ''
         The entirety of kickstart.nvim implemented as a nixCats flake.
-        With additional nix lsps for editing the nix part.
+        With additional Nix LSPs for editing the Nix part.
         This is to serve as the tutorial for using the nixCats lazy wrapper.
       '';
     };
@@ -122,11 +122,11 @@ with the string: `NOTE: nixCats:` so to find all of the info, search for that.
 
 One other note.
 
-If you install your grammars via `lazy.nvim` rather than `nix`,
+If you install your grammars via `lazy.nvim` rather than `Nix`,
 you will need to add a c compiler to your `lspsAndRuntimeDeps` section
-in your `categoryDefinitions`
+in your `categoryDefinitions`.
 
-If you install your grammars via nix rather than `lazy.nvim`,
+If you install your grammars via Nix rather than `lazy.nvim`,
 the only methods supported via the `lazy.nvim` wrapper are the following.
 >nix
   pkgs.vimPlugins.nvim-treesitter.withAllGrammars
@@ -147,33 +147,31 @@ Summary: as long as `pkgs.neovimUtils.grammarToPlugin` is called on it somehow, 
 
 Any other ways will still work in nixCats if they would work in other schemes,
 but not necessarily when using the lazy wrapper,
-because the lazy wrapper has to be given their paths from nix,
+because the lazy wrapper has to be given their paths from Nix,
 and thus need to be sorted from other plugins somehow.
 
 ---------------------------------------------------------------------------------
                                                        *nixCats.luaUtils.paq-nvim*
-load the plugins via paq-nvim when not on nix
+Load the plugins via paq-nvim when not on Nix
 YOU are in charge of putting the plugin
-urls and build steps in there, which will only be used when not on nix,
+urls and build steps in there, which will only be used when not on Nix,
 and you should keep any setup functions
 OUT of that file, as they are ONLY loaded when this
-configuration is NOT loaded via nix.
+configuration is NOT loaded via Nix.
 
-The way to think of this is, its very
-similar to the main nix file for nixCats
+The way to think of this is as very similar to the main Nix file for nixCats.
 
-It can be used to download your plugins,
-and it has an opt for optional plugins.
+It can be used to download your plugins, and it has an opt for optional plugins.
 
-we will do all our loading and configuring
+We will do all our loading and configuring
 elsewhere in our configuration, so that
-we dont have to write it twice.
+we don't have to write it twice.
 
 All the rest of the setup will be done using the normal setup functions later,
 thus working regardless of what method loads the plugins.
 only stuff pertaining to downloading and building should be added to paq.
 >lua
-  require('nixCatsUtils.catPacker').setup({
+  require('NixCatsUtils.catPacker').setup({
     { "BirdeeHub/lze", },
     { "stevearc/oil.nvim", },
     { 'joshdick/onedark.vim', },
@@ -188,14 +186,14 @@ only stuff pertaining to downloading and building should be added to paq.
     { 'nvim-telescope/telescope-ui-select.nvim', opt = true, },
     {'nvim-telescope/telescope.nvim', opt = true, },
 
-    -- lsp
+    -- LSP
     { 'williamboman/mason.nvim', opt = true, },
     { 'williamboman/mason-lspconfig.nvim', opt = true, },
     { 'j-hui/fidget.nvim', opt = true, },
     { 'neovim/nvim-lspconfig', opt = true, },
 
     --  NOTE:  we take care of lazy loading elsewhere in an autocommand
-      -- so that we can use the same code on and off nix.
+      -- so that we can use the same code on and off Nix.
       -- so here we just tell it not to auto load it
     { 'folke/lazydev.nvim', opt = true, },
 
@@ -203,8 +201,8 @@ only stuff pertaining to downloading and building should be added to paq.
     { 'onsails/lspkind.nvim', opt = true, },
 
     -- NOTE: when lazy loading, you might need to make the name
-    -- match the name from nix, so that you can call
-    -- packadd with the same name both on and off nix.
+    -- match the name from Nix, so that you can call
+    -- packadd with the same name both on and off Nix.
     { 'L3MON4D3/LuaSnip', opt = true, as = "luasnip", },
 
     { 'saadparwaiz1/cmp_luasnip', opt = true, },
@@ -249,7 +247,7 @@ only stuff pertaining to downloading and building should be added to paq.
 
   })
 <
-  OK, again, none of the stuff in this file is needed
-  if you only load this setup via nix, but it is an option.
+  Okay, again, none of the stuff in this file is needed
+  if you only load this setup via Nix, but it is an option.
 =================================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/nixCatsHelp/nixCats_modules.txt
+++ b/nixCatsHelp/nixCats_modules.txt
@@ -21,7 +21,7 @@ We create the module by exporting the following in our flake outputs.
       categoryDefinitions packageDefinitions extra_pkg_config;
 };
 
-If moduleNamespace is omitted, it will default to `[ defaultPackageName ]`
+If moduleNamespace is omitted, it will default to `[ defaultPackageName ]`.
 
 moduleNamespace controls the namespace for the module options.
 
@@ -31,9 +31,9 @@ Then you would `my_mods.nixCats.enable = true;`
 and `my_mods.nixCats.packageNames = [ "package" "names" "toinstall" ];`
 
 If you do not have a luaPath, you may pass it a keepLua builder.
-utils.mkNixosModules exports a nixos module with the following options,
-and utils.mkHomeModules exports a home-manager module with the SAME EXACT options
-as the nixos module has for system, but for the user managed by home-manager.
+utils.mkNixosModules exports a NixOS module with the following options,
+and utils.mkHomeModules exports a Home Manager module with the SAME EXACT options
+as the NixOS module has for system, but for the user managed by Home Manager.
 
 IMPORTANT
 By default, the module inherits pkgs.config from the system's pkgs object,
@@ -41,8 +41,7 @@ and its overlays AND the flake's overlays and nixCats config,
 as well as the flake's nixpkgs source (by default).
 It will inherit things from your system,
 but your system will not inherit things from nixCats,
-other than the packages themselves in config.${defaultPackageName}.out
-
+other than the packages themselves in config.${defaultPackageName}.out.
 >nix
   options = with lib; {
 
@@ -53,7 +52,7 @@ other than the packages themselves in config.${defaultPackageName}.out
         default = null;
         type = types.nullOr (types.anything);
         description = ''
-          a different nixpkgs import to use. By default will use the one from the flake, or `pkgs.path`.
+          A different nixpkgs import to use. By default will use the one from the flake, or `pkgs.path`.
         '';
         example = ''
           nixpkgs_version = inputs.nixpkgs
@@ -75,7 +74,7 @@ other than the packages themselves in config.${defaultPackageName}.out
       enable = mkOption {
         default = false;
         type = types.bool;
-        description = "Enable the ${defaultPackageName} module";
+        description = "Enable the ${defaultPackageName} module.";
       };
 
       dontInstall = mkOption {
@@ -83,7 +82,7 @@ other than the packages themselves in config.${defaultPackageName}.out
         type = types.bool;
         description = ''
           If true, do not output to packages list,
-          output only to config.${defaultPackageName}.out
+          output only to config.${defaultPackageName}.out.
         '';
       };
 
@@ -91,7 +90,7 @@ other than the packages themselves in config.${defaultPackageName}.out
         default = luaPath;
         type = types.oneOf [ types.str types.path ];
         description = (literalExpression ''
-          The path to your nvim config directory in the store.
+          The path to your Neovim config directory in the store.
           In the base nixCats flake, this is "${./.}".
         '');
         example = (literalExpression "${./.}/userLuaConfig");
@@ -100,7 +99,7 @@ other than the packages themselves in config.${defaultPackageName}.out
       packageNames = mkOption {
         default = if packageDefinitions ? defaultPackageName then [ "${defaultPackageName}" ] else [];
         type = (types.listOf types.str);
-        description = ''A list of packages from packageDefinitions to include'';
+        description = ''A list of packages from packageDefinitions to include.'';
         example = ''
           packageNames = [ "nixCats" ]
         '';
@@ -111,21 +110,21 @@ other than the packages themselves in config.${defaultPackageName}.out
           default = "replace";
           type = types.enum [ "replace" "merge" "discard" ];
           description = ''
-            the merge strategy to use for categoryDefinitions inherited from the package this module was based on
-            choose between "replace", "merge" or "discard"
-            replace uses utils.mergeCatDefs
-            merge uses utils.deepmergeCats
-            discard does not inherit
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+            The merge strategy to use for categoryDefinitions inherited from the package this module was based on.
+            Choose between "replace", "merge" or "discard":
+            - replace uses utils.mergeCatDefs
+            - merge uses utils.deepmergeCats
+            - discard does not inherit.
+            See :help nixCats.flake.outputs.exports for more info on the merge strategy options.
           '';
         };
         replace = mkOption {
           default = null;
           type = types.nullOr (catDef "replace");
           description = (literalExpression ''
-            see :help nixCats.flake.outputs.categories
-            uses utils.mergeCatDefs to recursively update old categories with new values
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+            See :help nixCats.flake.outputs.categories.
+            Uses utils.mergeCatDefs to recursively update old categories with new values.
+            See :help nixCats.flake.outputs.exports for more info on the merge strategy options.
           '');
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -136,9 +135,9 @@ other than the packages themselves in config.${defaultPackageName}.out
           default = null;
           type = types.nullOr (catDef "merge");
           description = ''
-            see :help nixCats.flake.outputs.categories
-            uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+            See :help nixCats.flake.outputs.categories.
+            Uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined.
+            See :help nixCats.flake.outputs.exports for more info on the merge strategy options.
           '';
           example = ''
             # see :help nixCats.flake.outputs.categories
@@ -152,25 +151,25 @@ other than the packages themselves in config.${defaultPackageName}.out
           default = "replace";
           type = types.enum [ "replace" "merge" "discard" ];
           description = ''
-            the merge strategy to use for packageDefinitions inherited from the package this module was based on
-            choose between "replace", "merge" or "discard"
-            replace uses utils.mergeCatDefs
-            merge uses utils.deepmergeCats
-            discard does not inherit
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+            The merge strategy to use for packageDefinitions inherited from the package this module was based on.
+            Choose between "replace", "merge" or "discard":
+            - replace uses utils.mergeCatDefs
+            - merge uses utils.deepmergeCats
+            - discard does not inherit.
+            See :help nixCats.flake.outputs.exports for more info on the merge strategy options.
           '';
         };
         merge = mkOption {
           default = null;
           description = ''
             VERY IMPORTANT when setting aliases for each package,
-            they must not be the same as ANY other neovim package for that user.
+            they must not be the same as ANY other Neovim package for that user.
             It will cause a build conflict.
 
             You can have as many nixCats installed per user as you want,
             as long as you obey that rule.
 
-            for information on the values you may return,
+            For information on the values you may return,
             see :help nixCats.flake.outputs.settings
             and :help nixCats.flake.outputs.categories
           '';
@@ -205,13 +204,13 @@ other than the packages themselves in config.${defaultPackageName}.out
           default = null;
           description = ''
             VERY IMPORTANT when setting aliases for each package,
-            they must not be the same as ANY other neovim package for that user.
+            they must not be the same as ANY other Neovim package for that user.
             It will cause a build conflict.
 
             You can have as many nixCats installed per user as you want,
             as long as you obey that rule.
 
-            for information on the values you may return,
+            For information on the values you may return,
             see :help nixCats.flake.outputs.settings
             and :help nixCats.flake.outputs.categories
           '';
@@ -244,12 +243,12 @@ other than the packages themselves in config.${defaultPackageName}.out
         };
       };
 
-      # in addition, the nixos module also has per-user options if desired.
+      # in addition, the NixOS module also has per-user options if desired.
 
       users = mkOption {
         default = {};
         description = ''
-          same as system config but per user instead
+          Same as system config but per user instead.
         '';
         type = with types; attrsOf (submodule {
           options = {
@@ -263,7 +262,7 @@ other than the packages themselves in config.${defaultPackageName}.out
               default = luaPath;
               type = types.str;
               description = ''
-                The path to your nvim config directory in the store.
+                The path to your Neovim config directory in the store.
                 In the base nixCats flake, this is "''${./.}".
               '';
               example = ''"''${./.}/userLuaConfig"'';
@@ -281,13 +280,12 @@ other than the packages themselves in config.${defaultPackageName}.out
 I have condensed it here, but notice at the end it outputs
 all the same options for each user when in a nixosModule as well?
 
-in addition, there are some config values that can be used to reference the
+In addition, there are some config values that can be used to reference the
 configs made in the module
 >nix
   config.${defaultPackageName}.out.packages.<PACKAGE_NAME>
 <
-
-and if using the nixos module there is ALSO
+and if using the NixOS module there is ALSO
 >nix
   config.${defaultPackageName}.out.users.<USER_NAME>.packages.<PACKAGE_NAME>
 <

--- a/nixCatsHelp/nixCats_overriding.txt
+++ b/nixCatsHelp/nixCats_overriding.txt
@@ -154,14 +154,14 @@ are not a set or a derivation and adding any new values.
               })
             '';
           }
-          # the home manager syntax for plugins is supported by nixCats
+          # The Home Manager syntax for plugins is supported by nixCats,
           # which is useful for one-off cases like this.
-          # here we use it to lazy load neorg on neorg filetype
+          # Here we use it to lazy load neorg on neorg filetype.
         ];
       };
-      # in addiion to the home-manager syntax,
+      # In addition to the Home Manager syntax,
       # you could also source the current directory ON TOP of the one in luaPath.
-      # if you want to make it also respect wrapRc, you can access the value
+      # If you want to make it also respect wrapRc, you can access the value
       # of wrapRc in the settings set provided to the function.
       # optionalLuaAdditions = {
       #   newcat = let
@@ -185,7 +185,7 @@ are not a set or a derivation and adding any new values.
     });
   });
 <
-Ok so we have a new category. But it isnt enabled!
+Okay, so we have a new category. But it isn't enabled!
 
 We need to make a package with the `newcat` category enabled!
 
@@ -240,8 +240,8 @@ within a flake, or a devShell or anywhere else.
 You could have a base configuration, with a bunch of categories disabled by
 default, and enable only the ones you need in project shells if you wanted.
 
-You can have a package based on any of your other packages but with wrapRc =
-false for testing lua without rebuild.
+You can have a package based on any of your other packages but with `wrapRc =
+false` for testing Lua without rebuild.
 
 The packages themselves also output modules via passthru.
 You can still output modules and overlays from a package built for only a
@@ -260,7 +260,7 @@ even easier. Just dont merge anything from prev.
 As you can see, overriding provides a very powerful way to customize your
 packages upon import somewhere else, and works very effectively with the
 nixCats category scheme. Overriding just the packageDefinitions set
-alone can produce wildly different neovim packages, and the more attention
+alone can produce wildly different Neovim packages, and the more attention
 paid to how you categorize, the better those options become.
 
 Have fun!

--- a/nixCatsHelp/nixCats_plugin.txt
+++ b/nixCatsHelp/nixCats_plugin.txt
@@ -1,22 +1,22 @@
 =======================================================================================
 NIX CATEGORIES                                                       *nixCats*
 
-For help with the nix flake files, see :help |nixCats.flake|
+For help with the Nix flake files, see :help |nixCats.flake|.
 
 *******************************************************
 AN IMPORTANT NOTE:
 
 <1> When editing the files within the flake directory,
-nix will not package a new file if it isn't staged in git.
-run git add before rebuilding it whenever adding a new file.
-Using wrapRc = true would mean this also applies to lua files.
-In fact, when wrapRc = true, even changes within a lua file
-will not be reflected unless you run git add.
+Nix will not package a new file if it isn't staged in git.
+run `git add` before rebuilding it whenever adding a new file.
+Using `wrapRc = true` would mean this also applies to Lua files.
+In fact, when `wrapRc = true`, even changes within a Lua file
+will not be reflected unless you run `git add`.
 *******************************************************
 
-nixCats: returns category names included by nix for this package 
+nixCats: returns category names included by Nix for this package
 
-Use a dot-separated string to check if this neovim was packaged with 
+Use a dot-separated string to check if this Neovim was packaged with
 a particular category included:
 >lua
     if nixCats('lua.someSubcategory') then
@@ -24,10 +24,10 @@ a particular category included:
     end
 <
 Checking a category that is not present rather than false,
-will still return false from this if statement because nil in lua is "falsey"
-I.e. if nix was not a category you included a value true or false for,
+will still return false from this if statement because `nil` in Lua is "falsey".
+That is, if Nix was not a category you included a value true or false for,
 it would evaluate as if it was false.
-if your category has an illegal lua name you may instead use this syntax
+If your category has an illegal Lua name you may instead use this syntax
 >lua
     nixCats { 'attr-set', "path", "to", [[valu.e'!#$@]] }
 <
@@ -58,7 +58,6 @@ They will be replaced.
 If in your flake, your package definition looked like this:
   see :help |nixCats.flake.outputs.packageDefinitions|
 >nix
-
   packageDefinitions = {
     nixCats = { pkgs, ... }@misc: {
       settings = settings.nixCats; 
@@ -73,13 +72,13 @@ If in your flake, your package definition looked like this:
           subtest1 = true;
         };
         debug = false;
-        # this does not have an associated category of plugins, 
-        # but lua can still check for it
+        # This does not have an associated category of plugins,
+        # but Lua can still check for it.
         lspDebugMode = false;
-        # by default, we dont want lazy.nvim
-        # we could omit this for the same effect
+        # By default, we don't want lazy.nvim.
+        # We could omit this for the same effect.
         lazy = false;
-        # you could also pass something else:
+        # You could also pass something else:
         themer = true;
         colorscheme = "onedark";
         theBestCat = "says meow!!";
@@ -97,7 +96,6 @@ If in your flake, your package definition looked like this:
       };
     };
   };
-
 <
 Using:
 >vim
@@ -148,8 +146,8 @@ null will become nil
 numbers will remain numbers
 derivations will become store paths
 
-everything that isnt true, false, null, 
-a list, or a set becomes a lua string.
+everything that isn't true, false, null,
+a list, or a set becomes a Lua string.
 it uses "[[${builtins.toString value}]]"
 in order to achieve this.
 It will throw an error if you pass an uncalled function.
@@ -183,19 +181,17 @@ You could use it to pass information like port numbers or paths
 Or whatever else you want.
 
 In addition to `nixCats.cats`, nixCats also contains other info.
-
 >lua
   nixCats.pawsible
     -- contains a final set of all the plugins included
     -- in the package and their paths, and the path to treesitter parsers.
-    -- does not include lsps and runtime dependencies,
+    -- does not include LSPs and runtime dependencies,
     -- you can retrieve their paths with vim.fn.exepath if needed.
 
   nixCats.settings
     -- contains the settings set for the package
 <
-
-you can view these for debugging purposes with `:NixCats settings` and
+You can view these for debugging purposes with `:NixCats settings` and
 `:NixCats pawsible` user commands.
 
 You may also use the following to debug. Using
@@ -205,8 +201,7 @@ will print the value of `nixCats('path.to.value')` for debugging purposes.
 In addition to the user commands, you may access these items directly within
 vimscript!
 
-`GetNixCat(value)` is equivalent to the `nixCats(value)` command in
-lua.
+`GetNixCat(value)` is equivalent to the `nixCats(value)` command in Lua.
 
 `GetNixSettings()` is `require('nixCats').settings`
 

--- a/nixCatsHelp/nix_LSPS.txt
+++ b/nixCatsHelp/nix_LSPS.txt
@@ -3,10 +3,10 @@ MASON AND LSPCONFIG                                             *nixCats.LSPs*
                                                           *nixCats.LSPs.mason*
 
 This is a method you may use to make sure mason only tries to download stuff
-when you did not install neovim via nixCats
+when you did not install Neovim via nixCats
 
 It functions the same as what kickstart.nvim does for its mason setup.
-However, when loaded via nix,
+However, when loaded via Nix,
 it skips mason and passes them straight to nvim-lspconfig
 
 When installing via pckr, install mason via pckr. Then wherever you set up
@@ -15,7 +15,7 @@ The stuff added to servers table is what is passed to lspconfig/mason
 
 >lua
   if nixCats('neonixdev') then
-    -- NOTE: Lazydev will make your lua lsp stronger for neovim config
+    -- NOTE: Lazydev will make your Lua LSP stronger for Neovim config
     -- NOTE: we are also using this as an opportunity to show you how to lazy load plugins!
     -- This plugin was added to the optionalPlugins section of the main flake.nix of this repo.
     -- Thus, it is not loaded and must be packadded.
@@ -23,7 +23,7 @@ The stuff added to servers table is what is passed to lspconfig/mason
       group = vim.api.nvim_create_augroup('nixCats-lazydev', { clear = true }),
       pattern = { 'lua' },
       callback = function(event)
-        -- NOTE: Use `:NixCats pawsible` to see the names of all plugins downloaded via nix for packadd
+        -- NOTE: Use `:nixCats pawsible` to see the names of all plugins downloaded via Nix for packad.
         vim.cmd.packadd('lazydev.nvim')
         require('lazydev').setup({
           library = {
@@ -116,8 +116,8 @@ The stuff added to servers table is what is passed to lspconfig/mason
   end
 
   -- This is this flake's version of what kickstarter has set up for mason handlers.
-  -- This is a convenience function that calls lspconfig on the lsps we downloaded via nix
-  -- This will not download your lsp. Nix does that.
+  -- This is a convenience function that calls lspconfig on the LSPs we downloaded via nix
+  -- This will not download your LSP --- Nix does that.
 
   --  Add any additional override configuration in the following tables. They will be passed to
   --  the `settings` field of the server config. You must look up that documentation yourself.
@@ -183,7 +183,7 @@ The above snippet mentions another file at the end.
 
 caps-on_attach.lua or 'myLuaConf.LSPs.caps-on_attach'
 
-It is simply a file containing the function we want to run on lsp attach, and a
+It is simply a file containing the function we want to run on LSP attach, and a
 function to return our completion capabilities object.
 
 It looks like this:


### PR DESCRIPTION
Standardised capitalisation of proper nouns[1] and placed more code fragments in backticks. Also added some missing punctuation, replaced 'ok' with 'okay'[2], and added bullet points to some descriptions in nixCats_modules.txt. There may be a couple of other changes in order to make formatting work, but I've kept these to a minimum.

I've been quite careful to avoid changing the capitalisation of anything in code fragments (outside of comments and text strings), but it's worth me saying that I may have missed some. Hopefully not too many; I didn't just search and replace.

[1] Nix, Lua, GitHub, LSP, Python, Neovim, Mason, Zsh, Home Manager

[2] I realised after pushing that both 'OK' and 'okay' are equally standard, and the former actually came first. So it's up to you which you prefer (but at least 'OK' should be capitalised, because it's a humorous acronym for 'all correct').