### PR TITLE
clarify template docs

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,1 +1,5 @@
-Get an overview of the available templates at: [nixcats.org/nixCats_templates.html](https://nixcats.org/nixCats_templates.html)
+See
+[nixcats.org/nixCats_templates.html](https://nixcats.org/nixCats_templates.html)
+for a brief description of each template and
+[nixcats.org/nixCats_installation.html](https://nixcats.org/nixCats_installation.html)
+for recommendations.

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -1,24 +1,29 @@
 {
   default = {
     path = ./fresh;
-    description = "Starting point template for making your Neovim flake";
+    description = ''
+      Starting point template for making your Neovim flake.
+      This is the same as the `fresh` flake template.
+    '';
   };
   fresh = {
     path = ./fresh;
-    description = "Starting point template for making your Neovim flake";
+    description = ''
+      Starting point template for making your Neovim flake.
+    '';
   };
   home-manager = {
     path = ./home-manager;
     description = ''
-      demonstration of importing and using the nixCats module for Home-Manager
+      Demonstration of importing and using the nixCats module for Home Manager.
     '';
   };
   nixos = {
     path = ./nixos;
     description = ''
-      demonstration of importing and using the nixCats module for NixOS (and nix-darwin)
+      Demonstration of importing and using the nixCats module for NixOS (and nix-darwin).
 
-      same as home manager, but has the options repeated for per-user configurations
+      Same as the `home-manager` template, but has the options repeated for per-user configurations.
     '';
   };
   nixExpressionFlakeOutputs = {
@@ -29,28 +34,35 @@
 
       It is best practice to avoid using the system pkgs and its overlays in this method,
       as then you could not output packages for systems not defined in your system flake.
-      It creates a new one instead to use, just like the flake template does.
+      It creates a new one instead to use, just like the `fresh` flake template does.
 
       Call it from your system flake and call it with inputs as arguments.
     '';
   };
   example = {
     path = ./example;
-    description = "an idiomatic nixCats example configuration using lze for lazy loading and paq.nvim for backup when not using nix";
+    description = ''
+      An idiomatic nixCats example configuration using
+      lze for lazy loading and paq.nvim for backup when not using nixCats-nvim.
+
+      See also https://github.com/BirdeeHub/nixCats-nvim/tree/main/templates/example#README.md.
+      '';
   };
   kickstart-nvim = {
     path = ./kickstart-nvim;
     description = ''
       The entirety of kickstart.nvim implemented as a nixCats flake.
-      With additional Nix LSPs for editing the nix part.
+      With additional Nix LSPs for editing the Nix part.
       This is to serve as the tutorial for using the nixCats lazy wrapper.
+
+      See also https://github.com/BirdeeHub/nixCats-nvim/tree/main/templates/kickstart-nvim#README.md.
     '';
   };
   LazyVim = {
     path = ./LazyVim;
     description = ''
-      How to get the LazyVim distribution up and running
-      see the kickstart-nvim template for more info on the lazy wrapper or other utilities used.
+      How to get the LazyVim distribution up and running.
+      See the `kickstart-nvim` template for more info on the lazy wrapper or other utilities used.
     '';
   };
   overwrite = {
@@ -61,17 +73,17 @@
       achieved via the OVERRIDE function.
 
       Equivalent to the default flake template
-      or nixExpressionFlakeOutputs except
-      for using overrides
+      or `nixExpressionFlakeOutputs` except
+      for using overrides.
 
-      every nixCats package is a full nixCats-nvim
+      Every nixCats package is a full nixCats-nvim.
     '';
   };
   luaUtils = {
     path = ./luaUtils;
     description = ''
-      A template that includes lua utils for using neovim package managers
-      when your config file is not loaded via nix.
+      A template that includes Lua utils for using Neovim package managers
+      when your config file is not loaded via Nix.
     '';
   };
   overriding = {
@@ -90,15 +102,15 @@
   overlayHub = {
     path = ./overlayHub;
     description = ''
-      A template for overlays/default.nix
-      :help nixCats.flake.nixperts.overlays
+      A template for overlays/default.nix.
+      See `:help nixCats.flake.nixperts.overlays`.
     '';
   };
   overlayFile = {
     path = ./overlayfile;
     description = ''
       A template for an empty overlay file defined as described in
-      :help nixCats.flake.nixperts.overlays
+      `:help nixCats.flake.nixperts.overlays`.
     '';
   };
 }


### PR DESCRIPTION
Minor clarifications. Before merging:
- I've added backticks for formatting. Does this work with your website generation?
- Same question for links to README files.
- I'm guessing this would be complicated, but in case it isn't, is it possible to make the website say `.../nixCats` instead of explicitly `.../nixCats#default`?