### PR TITLE
Fix outdated link in LSPs configuration example

### DIFF
--- a/templates/example/lua/myLuaConf/LSPs/init.lua
+++ b/templates/example/lua/myLuaConf/LSPs/init.lua
@@ -71,7 +71,7 @@ end
 
 --  Add any additional override configuration in the following tables. They will be passed to
 --  the `settings` field of the server config. You must look up that documentation yourself.
---  All of them are listed in https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
+--  All of them are listed in https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md
 --
 --  If you want to override the default filetypes that your language server will attach to you can
 --  define the property 'filetypes' to the map in question.


### PR DESCRIPTION
This PR updates an outdated link in the file nixCats-nvim/templates/example/lua/myLuaConf/LSPs/init.lua. The original link redirected to a new URL, and I have replaced it with the updated link.