### PR TITLE
fix: remove duplicate nvim-treesitter plugin entry from LazyNvim template

### DIFF
--- a/templates/LazyVim/flake.nix
+++ b/templates/LazyVim/flake.nix
@@ -125,7 +125,6 @@
           nvim-lspconfig
           nvim-notify
           nvim-spectre
-          nvim-treesitter
           nvim-treesitter-context
           nvim-treesitter-textobjects
           nvim-ts-autotag
@@ -142,7 +141,6 @@
           vim-startuptime
           which-key-nvim
           snacks-nvim
-
           nvim-treesitter-textobjects
           nvim-treesitter.withAllGrammars
           # This is for if you only want some of the grammars


### PR DESCRIPTION
The startupPlugins section previously included both `nvim-treesitter` and `nvim-treesitter.withAllGrammars`, which caused conflicts in TreeSitter initialization.  This ensures that TreeSitter initializes correctly with all parsers available, as having both entries caused TreeSitter to install only the default parsers.