### PR TITLE
gave debug command a popup buffer

### DIFF
--- a/builder/nixCats.lua
+++ b/builder/nixCats.lua
@@ -37,10 +37,6 @@ end
 
 function M.addGlobals()
 
-    ---:h nixCats
-    ---This function will return the nearest parent category value, unless the nearest
-    ---parent is a table, in which case that means a different subcategory
-    ---was enabled but this one was not. In that case it returns nil.
     ---@type nixCats
     _G.nixCats = M
 
@@ -57,23 +53,73 @@ function M.addGlobals()
     }
     -- command with debug info for nixCats setups
     vim.api.nvim_create_user_command('NixCats', function(opts)
+        local function show_popup(input)
+            local function mk_popup(text)
+                local contents = {}
+                for line in text:gmatch("[^\r\n]+") do
+                    table.insert(contents, line)
+                end
+                local bufnr = vim.api.nvim_create_buf(false, true)
+                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, contents)
+                vim.bo[bufnr].modifiable = false
+                vim.bo[bufnr].readonly = true
+
+                -- Get maximum width of text
+                local width = 0
+                for _, line in ipairs(contents) do
+                    width = math.max(width, #line)
+                end
+
+                -- cap to screen size with margin
+                local height = #contents
+                local win_width = math.min(width + 2, vim.o.columns - 4)
+                local win_height = math.min(height + 2, vim.o.lines - 4)
+                local popopts = {
+                    relative = "editor",
+                    width = win_width,
+                    height = win_height,
+                    row = (vim.o.lines - win_height) / 2,
+                    col = (vim.o.columns - win_width) / 2,
+                    style = "minimal",
+                    border = "rounded",
+                }
+
+                -- make the window
+                local win_id = vim.api.nvim_open_win(bufnr, true, popopts)
+                vim.wo[win_id].signcolumn = "no"
+                vim.wo[win_id].number = false
+                vim.wo[win_id].relativenumber = false
+
+                vim.api.nvim_buf_set_keymap(bufnr, "n", "q", "<Cmd>close<CR>", { noremap = true, silent = true })
+                vim.api.nvim_buf_set_keymap(bufnr, "n", "<Esc>", "<Cmd>close<CR>", { noremap = true, silent = true })
+            end
+            local ok, msg = pcall(mk_popup, input)
+            if not ok then
+                print("Popup failed to open due to error: " .. msg)
+                print("Falling back to print()")
+                print(input)
+            end
+        end
+
+        local display = vim.g.nixcats_debug_ui ~= false and show_popup or print
+
         if #opts.fargs == 0 then
-            print(vim.inspect(M.cats))
+            display(vim.inspect(M.cats))
             return
         elseif #opts.fargs == 1 then
             if vim.list_contains(attributes, opts.fargs[1]) then
-                print(vim.inspect(M[opts.fargs[1]]))
+                display(vim.inspect(M[opts.fargs[1]]))
                 return
             end
         elseif #opts.fargs == 2 then
             if opts.fargs[1] == 'cat' or opts.fargs[1] == 'get' then
-                print(vim.inspect(M.get(opts.fargs[2])))
+                display(vim.inspect(M.get(opts.fargs[2])))
                 return
             end
         elseif #opts.fargs > 2 then
             local first = table.remove(opts.fargs, 1)
             if first == 'cat' or first == 'get' then
-                print(vim.inspect(M.get(opts.fargs)))
+                display(vim.inspect(M.get(opts.fargs)))
                 return
             end
         end

--- a/builder/nixCatsMeta.lua
+++ b/builder/nixCatsMeta.lua
@@ -19,20 +19,24 @@ error("Cannot import a meta module")
 ---Contains all the defined categories that you COULD enable from nix
 ---Function form will return vim.tbl_get for the attrpath
 ---@field petShop table|fun(attrpath: string|string[]): any
----@field nixCatsPath string
----@field vimPackDir string
+---The path to your configuration for the package
 ---@field configDir string
+---Path to the nixCats wrapper script that launches nvim
 ---Useful for things such as vim-startuptime which must reference the wrapper's actual path
 ---@field packageBinPath string
+---The path to the packpath directory with all your plugins from nix
+---@field vimPackDir string
+---The path to the nixCats plugin
+---@field nixCatsPath string
 ---internal: this creates the nixCats global commands
----@field addGlobals fun() 
----:h nixCats
+---@field addGlobals fun()
+---See :h nixCats
 ---This function will return the nearest parent category value, unless the nearest
 ---parent is a table, in which case that means a different subcategory
 ---was enabled but this one was not. In that case it returns nil.
 ---@field get fun(category: string|string[]): any
 
----:h nixCats
+---See :h nixCats
 ---This function will return the nearest parent category value, unless the nearest
 ---parent is a table, in which case that means a different subcategory
 ---was enabled but this one was not. In that case it returns nil.

--- a/nixCatsHelp/nixCats_plugin.txt
+++ b/nixCatsHelp/nixCats_plugin.txt
@@ -182,70 +182,90 @@ Or whatever else you want.
 
 In addition to `nixCats.cats`, nixCats also contains other info.
 >lua
-  nixCats.pawsible
-    -- contains a final set of all the plugins included
-    -- in the package and their paths, and the path to treesitter parsers.
-    -- does not include LSPs and runtime dependencies,
-    -- you can retrieve their paths with vim.fn.exepath if needed.
-
-  nixCats.settings
-    -- contains the settings set for the package
-<
-You can view these for debugging purposes with `:NixCats settings` and
-`:NixCats pawsible` user commands.
-
-You may also use the following to debug. Using
-`:NixCats cat path.to.value` or `:NixCats cat path to value`
-will print the value of `nixCats('path.to.value')` for debugging purposes.
-
-In addition to the user commands, you may access these items directly within
-vimscript!
-
-`GetNixCat(value)` is equivalent to the `nixCats(value)` command in Lua.
-
-`GetNixSettings()` is `require('nixCats').settings`
-
-`GetNixPawsible()` is `require('nixCats').pawsible`
-
-`GetAllNixCats()` is `require('nixCats').cats`
-
-All of the following may be accessed by `require('nixCats').<item>`,
-or :NixCats <item>, except the :NixCats user command also
-has the `cat` subcommand to preview the value from `nixCats("catname")`,
->lua
   ---@class nixCats.main
+  ---
   ---See :h nixCats.flake.outputs.packageDefinitions
   ---Function form will return vim.tbl_get for the attrpath
   ---@field cats table|fun(attrpath: string|string[]): any
+  ---
   ---See :h nixCats.flake.outputs.settings
   ---Function form will return vim.tbl_get for the attrpath
   ---@field settings table|fun(attrpath: string|string[]): any
+  ---
   ---See :h nixCats.flake.outputs.packageDefinitions
   ---Function form will return vim.tbl_get for the attrpath
   ---@field extra table|fun(attrpath: string|string[]): any
+  ---
   ---Contains the final set of plugins added for this package
   ---Function form will return vim.tbl_get for the attrpath
   ---@field pawsible table|fun(attrpath: string|string[]): any
+  ---
   ---Contains all the defined categories that you COULD enable from nix
   ---Function form will return vim.tbl_get for the attrpath
   ---@field petShop table|fun(attrpath: string|string[]): any
-  ---@field nixCatsPath string
-  ---@field vimPackDir string
+  ---
+  ---The path to your configuration for the package
   ---@field configDir string
+  ---
+  ---Path to the nixCats wrapper script that launches nvim
   ---@field packageBinPath string
+  ---
+  ---The path to the packpath directory with all your plugins from nix
+  ---Useful for things such as vim-startuptime which must reference the wrapper's actual path
+  ---@field vimPackDir string
+  ---
+  ---The path to the nixCats plugin
+  ---@field nixCatsPath string
+  ---
   ---internal: this creates the nixCats global commands
   ---@field addGlobals fun() 
+  ---
   ---:h nixCats
   ---This function will return the nearest parent category value, unless the nearest
   ---parent is a table, in which case that means a different subcategory
   ---was enabled but this one was not. In that case it returns nil.
   ---@field get fun(category: string|string[]): any
 
-  ---:h nixCats
-  ---This function will return the nearest parent category value, unless the nearest
-  ---parent is a table, in which case that means a different subcategory
-  ---was enabled but this one was not. In that case it returns nil.
+  ---The main nixCats("cat.name") function
+  ---It is an alias for `nixCats.get("cat.name")`
   ---@alias nixCats nixCats.main | fun(category: string|string[]): any
 <
+All of the above may be accessed in lua via
+`nixCats.<item>`, or `require('nixCats').<item>`, or `:NixCats` <item>,
+and the `:NixCats` user command also
+has the `cat` subcommand to preview the value from `nixCats("catname")`
+You can view these for debugging purposes with `:NixCats settings` and
+`:NixCats pawsible` user commands.
+
+Everything provided by the nixCats plugin can be printed
+for debugging purposes via the `:NixCats` user command.
+e.g. `:NixCats cats` shown above will print the `nixCats.cats` table.
+
+Using `:NixCats cat path.to.value` or `:NixCats cat path to value`
+will print the value of `nixCats('path.to.value')
+
+The debug command by default will create
+a popup window to display the information.
+
+If you don't like that, or are using neovim embedded
+in another application without buffer or window support,
+(such as vscode), you may set
+`vim.g.nixcats_debug_ui = false`
+which will cause it to do a simple `print(vim.inspect(value))` instead.
+Or, you can simply print them yourself!
+`print(vim.inspect(nixCats.cats))`
+
+In addition, you may also access these items directly within vimscript! >vim
+  v:lua.require('nixCats').cats
+<
+There are some helper functions included in the plugin that call that for you,
+but if you are going to use vimscript in neovim, knowing how to call lua is
+important. So, I showed the general way first.
+
+`GetNixCat(value)` is equivalent to the `nixCats(value)` command in Lua.
+`GetNixSettings()` is `require('nixCats').settings`
+`GetNixPawsible()` is `require('nixCats').pawsible`
+`GetAllNixCats()` is `require('nixCats').cats`
+
 ----------------------------------------------------------------------------------------
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
some plugins make print() an insufficient display method. It is also hard to copy paste the result without a mouse or something like tmux.

Now, by default the `:NixCats` command creates a temporary read only buffer that will also be easier to copy paste things out of.

If you do not like this behavior and want to go back to it just printing, you may set `vim.g.nixcats_debug_ui = false`