### PR TITLE
feat(overrides and pkgs): see below

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@v9
-    - run: nix flake check -L --impure ./tests
+    - run: nix flake check -L ./tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,8 @@ I welcome any help in making this happen.
 
 Run the tests with
 ```sh
-nix flake check --show-trace --impure -Lv ./tests
+nix flake check --show-trace -Lv ./tests
 ```
-
-The `--impure` flag is required to use `builtins.getFlake` on the example templates, but not for the other tests.
 
 I will slowly be adding tests to the tests directory.
 If anyone would like to add some tests, please do!

--- a/builder/builder_error.nix
+++ b/builder/builder_error.nix
@@ -1,48 +1,100 @@
 # Copyright (c) 2023 BirdeeHub 
 # Licensed under the MIT license 
 builtins.throw ''
-  The following arguments are accepted:
+Error calling main nixCats builder function `utils.baseBuilder`
 
-  # -------------------------------------------------------- #
+# -------------------------------------------------------- #
 
-  # the path to your ~/.config/nvim replacement within your nix config.
-  luaPath: # <-- must be a store path
+# Arguments
 
-  { # set of items for building the pkgs that builds your neovim
+## **luaPath** (`path` or `stringWithContext`)
+STORE PATH to your `~/.config/nvim` replacement.
 
-    , nixpkgs # <-- required
-    , system # <-- required
+## **pkgsParams** (`AttrSet`)
+set of items for building the pkgs that builds your neovim.
 
-    # type: (attrsOf listOf overlays) or (listOf overlays) or null
-    , dependencyOverlays ? null 
+accepted attributes are:
 
-    # import nixpkgs { config = extra_pkg_config; inherit system; }
-    , extra_pkg_config ? {} # type: attrs
+- `nixpkgs` (`path` | `input` | `channel`)
+: required unless using `pkgs`
+: allows path, or flake input
 
-    # any extra stuff for finalPackage.passthru
-    , nixCats_passthru ? {} # type: attrs
-  }:
+- `system` (`string`)
+: required unless using `pkgs`
+: or using --impure argument
 
-  # type: function with args { pkgs, settings, categories, name, extra, mkNvimPlugin, ... }:
-  # returns: set of sets of categories
-  # see :h nixCats.flake.outputs.categories
-  categoryDefinitions: 
+- `pkgs` (`channel`)
+: can be passed instead of `nixpkgs` and `system`
+: the resulting nvim will inherit overlays and other such modifications of the `pkgs` value
 
-  # type: function with args { pkgs, mkNvimPlugin, ... }:
-  # returns: { settings = {}; categories = {}; extra = {}; }
-  packageDefinitions: 
-  # see :h nixCats.flake.outputs.packageDefinitions
-  # see :h nixCats.flake.outputs.settings
+- `dependencyOverlays` (`listOf overlays` | `null`)
+: default = null
 
-  # name of the package to built from packageDefinitions
-  name: 
+- `extra_pkg_config` (`AttrSet`)
+: default = {}
+: the attrset passed to:
+: `import nixpkgs { config = extra_pkg_config; inherit system; }`
 
-  # -------------------------------------------------------- #
+- `extra_pkg_params` (`AttrSet`)
+: default = {}
+: `import nixpkgs (extra_pkg_params // { inherit system; })`
 
-  # Note:
-  When using override, all values shown above will
-  be top level attributes of prev, none will be nested.
+- `nixCats_passthru` (`AttrSet`)
+: default = {}
+: attrset of extra stuff for finalPackage.passthru
 
-  i.e. finalPackage.override (prev: { inherit (prev) dependencyOverlays; })
-    NOT prev.pkgsargs.dependencyOverlays or something like that
+## **categoryDefinitions** (`functionTo` `AttrSet`)
+type: function that returns set of sets of categories of dependencies.
+Called with the contents of the current package definition as arguments
+
+```nix
+{ pkgs, settings, categories, extra, name, mkNvimPlugin, ... }@packageDef: {
+  lspsAndRuntimeDeps = {
+    general = with pkgs; [ ];
+  };
+  startupPlugins = {
+    general = with pkgs.vimPlugins; [ ];
+    some_other_name = [];
+  };
+  # ...
+}
+```
+
+see :h [nixCats.flake.outputs.categories](https://nixcats.org/nixCats_format.html#nixCats.flake.outputs.categories)
+
+## **packageDefinitions** (`AttrsOf` `functionTo` `AttrSet`)
+set of functions that each represent the settings and included categories for a package.
+
+Among other info, things declared in settings, categories, and extra will be available in lua.
+
+```nix
+{
+  nvim = { pkgs, mkNvimPlugin, ... }: {
+    settings = {};
+    categories = {
+      general = true;
+      some_other_name = true;
+    };
+    extra = {};
+  };
+}
+```
+
+see :h [nixCats.flake.outputs.packageDefinitions](https://nixcats.org/nixCats_format.html#nixCats.flake.outputs.packageDefinitions)
+
+see :h [nixCats.flake.outputs.settings](https://nixcats.org/nixCats_format.html#nixCats.flake.outputs.settings)
+
+## **name** (`string`)
+name of the package to build from `packageDefinitions`
+
+# Note:
+
+When using override, all values shown above will
+be top level attributes of prev, none will be nested.
+
+i.e. `finalPackage.override (prev: { inherit (prev) dependencyOverlays; })`
+
+NOT `prev.pkgsParams.dependencyOverlays` or something like that
+
+---
 ''

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -3,284 +3,316 @@
 {
   nclib
   , utils
-}:
-{ luaPath
-, categoryDefinitions
-, packageDefinitions
-, name
-, nixpkgs
-, system ? (nixpkgs.system or builtins.system or import ./builder_error.nix)
-, extra_pkg_config ? {}
-, dependencyOverlays ? null
-, nixCats_passthru ? {}
-}:
-let
-  pkgs = with builtins; let
-    config = if ! (isAttrs extra_pkg_config) then import ./builder_error.nix
-      else (nixpkgs.config or {}) // extra_pkg_config;
-    overlays = if isList dependencyOverlays
-      then dependencyOverlays
-      else dependencyOverlays.${system} or [];
-  in if isAttrs extra_pkg_config && isAttrs nixCats_passthru
-    && isFunction categoryDefinitions && isAttrs packageDefinitions && isString name
-    && (isPath luaPath || (isString luaPath && hasContext luaPath) || luaPath.outPath or null != null)
-  then import (nixpkgs.path or nixpkgs.outPath or nixpkgs)
-    { inherit system config overlays; }
-  else import ./builder_error.nix;
+}: let
+  process_args = { luaPath
+  , categoryDefinitions
+  , packageDefinitions
+  , name
+  , ...
+  }@args:
+    assert with builtins; !(isFunction categoryDefinitions && isAttrs packageDefinitions && isString name && isAttrs (args.nixCats_passthru or {})
+      && (isPath luaPath || (isString luaPath && hasContext luaPath) || luaPath.outPath or null != null)) -> import ./builder_error.nix;
+  let
+    system = let
+      val = args.system or args.pkgs.system or args.nixpkgs.system or builtins.system or (import ./builder_error.nix);
+    in if builtins.isString val then val else import ./builder_error.nix;
+    extra_pkg_config = if ! (builtins.isAttrs args.extra_pkg_config or {})
+      then import ./builder_error.nix
+      else args.extra_pkg_config or {};
+    extra_pkg_params = if ! (builtins.isAttrs args.extra_pkg_params or {})
+      then import ./builder_error.nix
+      else args.extra_pkg_params or {};
 
-  mkNvimPlugin = src: pname:
-    pkgs.vimUtils.buildVimPlugin {
-      inherit pname src;
-      doCheck = false;
-      version = builtins.toString (src.lastModifiedDate or "master");
-    };
+    pkgs = with builtins; (let
+      overlays = if isList (args.dependencyOverlays or null) then args.dependencyOverlays else [];
+    in if (args.pkgs or null) != null && extra_pkg_config == {} && extra_pkg_params == {} && (args.pkgs.system or null) == system
+      then if overlays == [] then args.pkgs else args.pkgs.appendOverlays overlays
+      else import (args.pkgs.path or args.nixpkgs.path or args.nixpkgs.outPath or args.nixpkgs) ({
+          inherit system;
+          config = (args.pkgs.config or {}) // extra_pkg_config;
+          overlays = (args.pkgs.overlays or []) ++ overlays;
+        } // (args.extra_pkg_params or {})));
 
-  ncTools = pkgs.callPackage ./ncTools.nix { inherit nclib; };
+    mkNvimPlugin = src: pname:
+      pkgs.vimUtils.buildVimPlugin {
+        inherit pname src;
+        doCheck = false;
+        version = builtins.toString (src.lastModifiedDate or "master");
+      };
 
-  thisPackage = packageDefinitions.${name} { inherit pkgs mkNvimPlugin; };
-  settings = {
-    wrapRc = true;
-    viAlias = false;
-    vimAlias = false;
-    withNodeJs = false;
-    withRuby = true;
-    gem_path = null;
-    withPerl = false;
-    extraName = "";
-    withPython3 = true;
-    configDirName = "nvim";
-    unwrappedCfgPath = null;
-    autowrapRuntimeDeps = "suffix";
-    autoconfigure = "prefix";
-    aliases = null;
-    nvimSRC = null;
-    neovim-unwrapped = null;
-    suffix-path = false;
-    suffix-LD = false;
-    disablePythonSafePath = false;
-    disablePythonPath = true; # <- you almost certainly want this set to true
-    collate_grammars = true;
-    moduleNamespace = [ name ];
-  } // (thisPackage.settings or {});
+    ncTools = pkgs.callPackage ./ncTools.nix { inherit nclib; };
 
-  final_cat_defs_set = ({
-    startupPlugins = {};
-    optionalPlugins = {};
-    lspsAndRuntimeDeps = {};
-    sharedLibraries = {};
-    propagatedBuildInputs = {};
-    environmentVariables = {};
-    extraWrapperArgs = {};
-    /* the function you would have passed to python.withPackages */
-    extraPython3Packages = {};
-    extraPython3wrapperArgs = {};
-  # same thing except for lua.withPackages
-    extraLuaPackages = {};
-  # only for use when importing flake in a flake 
-  # and need to only add a bit of lua for an added plugin
-    optionalLuaAdditions = {};
-    optionalLuaPreInit = {};
-    bashBeforeWrapper = {};
-    # set of lists of lists of strings of other categories to enable
-    extraCats = {};
-  } // (categoryDefinitions {
-    # categories depends on extraCats
-    inherit categories settings pkgs name mkNvimPlugin;
-    extra = extraTableLua;
-  }));
-  inherit (final_cat_defs_set)
-  startupPlugins optionalPlugins lspsAndRuntimeDeps
-  propagatedBuildInputs environmentVariables
-  extraWrapperArgs extraPython3Packages
-  extraLuaPackages optionalLuaAdditions
-  extraPython3wrapperArgs sharedLibraries
-  optionalLuaPreInit bashBeforeWrapper;
+    thisPackage = packageDefinitions.${name} { inherit pkgs mkNvimPlugin; };
+    settings = {
+      wrapRc = true;
+      viAlias = false;
+      vimAlias = false;
+      withNodeJs = false;
+      withRuby = true;
+      gem_path = null;
+      withPerl = false;
+      extraName = "";
+      withPython3 = true;
+      configDirName = "nvim";
+      unwrappedCfgPath = null;
+      autowrapRuntimeDeps = "suffix";
+      autoconfigure = "prefix";
+      aliases = null;
+      nvimSRC = null;
+      neovim-unwrapped = null;
+      suffix-path = false;
+      suffix-LD = false;
+      disablePythonSafePath = false;
+      disablePythonPath = true; # <- you almost certainly want this set to true
+      collate_grammars = true;
+      moduleNamespace = [ name ];
+    } // (thisPackage.settings or {});
 
-  categories = ncTools.applyExtraCats (thisPackage.categories or {}) final_cat_defs_set.extraCats;
-  extraTableLua = thisPackage.extra or {};
-  all_cat_names = ncTools.getCatSpace (builtins.attrValues final_cat_defs_set);
+    final_cat_defs_set = ({
+      startupPlugins = {};
+      optionalPlugins = {};
+      lspsAndRuntimeDeps = {};
+      sharedLibraries = {};
+      propagatedBuildInputs = {};
+      environmentVariables = {};
+      extraWrapperArgs = {};
+      /* the function you would have passed to python.withPackages */
+      extraPython3Packages = {};
+      extraPython3wrapperArgs = {};
+    # same thing except for lua.withPackages
+      extraLuaPackages = {};
+    # only for use when importing flake in a flake 
+    # and need to only add a bit of lua for an added plugin
+      optionalLuaAdditions = {};
+      optionalLuaPreInit = {};
+      bashBeforeWrapper = {};
+      # set of lists of lists of strings of other categories to enable
+      extraCats = {};
+    } // (categoryDefinitions {
+      # categories depends on extraCats
+      inherit categories settings pkgs name mkNvimPlugin;
+      extra = extraTableLua;
+    }));
+    inherit (final_cat_defs_set)
+    startupPlugins optionalPlugins lspsAndRuntimeDeps
+    propagatedBuildInputs environmentVariables
+    extraWrapperArgs extraPython3Packages
+    extraLuaPackages optionalLuaAdditions
+    extraPython3wrapperArgs sharedLibraries
+    optionalLuaPreInit bashBeforeWrapper;
 
-  # this is what allows for dynamic packaging in flake.nix
-  # It includes categories marked as true, then flattens to a single list
-  filterAndFlatten = ncTools.filterAndFlatten categories;
-  # This one filters and flattens like above but for attrs of attrs 
-  # and then maps name and value
-  # into a list based on the function we provide it.
-  # its like a flatmap function but with a built in filter for category.
-  filterAndFlattenMapInnerAttrs = ncTools.filterAndFlattenMapInnerAttrs categories;
+    categories = ncTools.applyExtraCats (thisPackage.categories or {}) final_cat_defs_set.extraCats;
+    extraTableLua = thisPackage.extra or {};
+    all_cat_names = ncTools.getCatSpace (builtins.attrValues final_cat_defs_set);
 
-  # for the env vars section
-  FandF_envVarSet = set: pkgs.lib.pipe set [
-    (filterAndFlattenMapInnerAttrs (name: value: pkgs.lib.escapeShellArgs [ "--set" name value ]))
-    pkgs.lib.unique
-  ];
+    # this is what allows for dynamic packaging in flake.nix
+    # It includes categories marked as true, then flattens to a single list
+    filterAndFlatten = ncTools.filterAndFlatten categories;
+    # This one filters and flattens like above but for attrs of attrs 
+    # and then maps name and value
+    # into a list based on the function we provide it.
+    # its like a flatmap function but with a built in filter for category.
+    filterAndFlattenMapInnerAttrs = ncTools.filterAndFlattenMapInnerAttrs categories;
 
-  # shorthand to reduce lispyness
-  filterFlattenUnique = s: pkgs.lib.unique (filterAndFlatten s);
-
-  # extraPythonPackages and the like require FUNCTIONS that return lists.
-  # so we make a function that returns a function that returns lists.
-  # this is used for the fields in the wrapper where the default value is (_: [])
-  combineCatsOfFuncs = section:
-    x: pkgs.lib.pipe section [
-      filterAndFlatten
-      (map (value: value x))
-      pkgs.lib.flatten
+    # for the env vars section
+    FandF_envVarSet = set: pkgs.lib.pipe set [
+      (filterAndFlattenMapInnerAttrs (name: value: pkgs.lib.escapeShellArgs [ "--set" name value ]))
       pkgs.lib.unique
     ];
 
-  # see :help nixCats
-  # this function gets passed all the way into the wrapper so that we can also add
-  # other dependencies that get resolved later in the process such as treesitter grammars.
-  nixCats = allPluginDeps: let
-    nixCats_config_location = if settings.wrapRc == true then luaPath
-      else if settings.unwrappedCfgPath == null
-        then utils.n2l.types.inline-unsafe.mk { body = ''vim.fn.stdpath("config")''; }
-      else settings.unwrappedCfgPath;
+    # shorthand to reduce lispyness
+    filterFlattenUnique = s: pkgs.lib.unique (filterAndFlatten s);
 
-    categoriesPlus = categories // {
-      nixCats_wrapRc = settings.wrapRc;
-      nixCats_packageName = name;
-      inherit nixCats_config_location;
-    };
-    settingsPlus = settings // {
-      nixCats_packageName = name;
-      inherit nixCats_config_location;
+    # extraPythonPackages and the like require FUNCTIONS that return lists.
+    # so we make a function that returns a function that returns lists.
+    # this is used for the fields in the wrapper where the default value is (_: [])
+    combineCatsOfFuncs = section:
+      x: pkgs.lib.pipe section [
+        filterAndFlatten
+        (map (value: value x))
+        pkgs.lib.flatten
+        pkgs.lib.unique
+      ];
+
+    # see :help nixCats
+    # this function gets passed all the way into the wrapper so that we can also add
+    # other dependencies that get resolved later in the process such as treesitter grammars.
+    nixCats = allPluginDeps: let
+      nixCats_config_location = if settings.wrapRc == true then luaPath
+        else if settings.unwrappedCfgPath == null
+          then utils.n2l.types.inline-unsafe.mk { body = ''vim.fn.stdpath("config")''; }
+        else settings.unwrappedCfgPath;
+
+      categoriesPlus = categories // {
+        nixCats_wrapRc = settings.wrapRc;
+        nixCats_packageName = name;
+        inherit nixCats_config_location;
+      };
+      settingsPlus = settings // {
+        nixCats_packageName = name;
+        inherit nixCats_config_location;
+      };
+
+      cats = ncTools.mkLuaFileWithMeta "cats.lua" categoriesPlus;
+      settingsTable = ncTools.mkLuaFileWithMeta "settings.lua" settingsPlus;
+      petShop = ncTools.mkLuaFileWithMeta "petShop.lua" all_cat_names;
+      depsTable = ncTools.mkLuaFileWithMeta "pawsible.lua" allPluginDeps;
+      extraItems = ncTools.mkLuaFileWithMeta "extra.lua" extraTableLua;
+    in pkgs.stdenv.mkDerivation {
+      name = "nixCats";
+      builder = pkgs.writeText "builder.sh" /*bash*/ ''
+        source $stdenv/setup
+        mkdir -p $out/lua/nixCats
+        mkdir -p $out/doc
+        cp ${./nixCats.lua} $out/lua/nixCats/init.lua
+        cp ${./nixCatsMeta.lua} $out/lua/nixCats/meta.lua
+        cp ${cats} $out/lua/nixCats/cats.lua
+        cp ${settingsTable} $out/lua/nixCats/settings.lua
+        cp ${depsTable} $out/lua/nixCats/pawsible.lua
+        cp ${petShop} $out/lua/nixCats/petShop.lua
+        cp ${extraItems} $out/lua/nixCats/extra.lua
+        cp -r ${../nixCatsHelp}/* $out/doc/
+      '';
     };
 
-    cats = ncTools.mkLuaFileWithMeta "cats.lua" categoriesPlus;
-    settingsTable = ncTools.mkLuaFileWithMeta "settings.lua" settingsPlus;
-    petShop = ncTools.mkLuaFileWithMeta "petShop.lua" all_cat_names;
-    depsTable = ncTools.mkLuaFileWithMeta "pawsible.lua" allPluginDeps;
-    extraItems = ncTools.mkLuaFileWithMeta "extra.lua" extraTableLua;
-  in pkgs.stdenv.mkDerivation {
-    name = "nixCats";
-    builder = pkgs.writeText "builder.sh" /*bash*/ ''
-      source $stdenv/setup
-      mkdir -p $out/lua/nixCats
-      mkdir -p $out/doc
-      cp ${./nixCats.lua} $out/lua/nixCats/init.lua
-      cp ${./nixCatsMeta.lua} $out/lua/nixCats/meta.lua
-      cp ${cats} $out/lua/nixCats/cats.lua
-      cp ${settingsTable} $out/lua/nixCats/settings.lua
-      cp ${depsTable} $out/lua/nixCats/pawsible.lua
-      cp ${petShop} $out/lua/nixCats/petShop.lua
-      cp ${extraItems} $out/lua/nixCats/extra.lua
-      cp -r ${../nixCatsHelp}/* $out/doc/
+    buildInputs = filterFlattenUnique propagatedBuildInputs;
+
+    normalized = pkgs.callPackage ./normalizePlugins.nix {
+      startup = filterAndFlatten startupPlugins;
+      optional = filterAndFlatten optionalPlugins;
+      inherit (utils) n2l;
+    };
+
+    customRC = let
+      optLuaPre = let
+        lua = if builtins.isString optionalLuaPreInit
+          then optionalLuaPreInit
+          else builtins.concatStringsSep "\n"
+          (filterFlattenUnique optionalLuaPreInit);
+      in if lua != "" then "dofile([[${pkgs.writeText "optLuaPre.lua" lua}]])" else "";
+      optLuaAdditions = let
+        lua = if builtins.isString optionalLuaAdditions
+          then optionalLuaAdditions
+          else builtins.concatStringsSep "\n"
+          (filterFlattenUnique optionalLuaAdditions);
+      in if lua != "" then "dofile([[${pkgs.writeText "optLuaAdditions.lua" lua}]])" else "";
+    in /*lua*/''
+      ${pkgs.lib.optionalString (settings.autoconfigure == "prefix" || settings.autoconfigure == true) normalized.passthru_initLua}
+      -- optionalLuaPreInit
+      ${optLuaPre}
+      -- lua from nix with pre = true
+      ${normalized.preInlineConfigs}
+      -- run the init.lua (or init.vim)
+      if vim.fn.filereadable(require('nixCats').configDir .. "/init.lua") == 1 then
+        dofile(require('nixCats').configDir .. "/init.lua")
+      elseif vim.fn.filereadable(require('nixCats').configDir .. "/init.vim") == 1 then
+        vim.cmd.source(require('nixCats').configDir .. "/init.vim")
+      end
+      -- all other lua from nix plugin specs
+      ${normalized.inlineConfigs}
+      -- optionalLuaAdditions
+      ${optLuaAdditions}
+      ${pkgs.lib.optionalString (settings.autoconfigure == "suffix") normalized.passthru_initLua}
     '';
-  };
 
-  buildInputs = filterFlattenUnique propagatedBuildInputs;
+    # cat our args
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
+    extraMakeWrapperArgs = let 
+      preORpostPATH = if settings.suffix-path then "suffix" else "prefix";
+      pathEnv = filterFlattenUnique lspsAndRuntimeDeps;
+      preORpostLD = if settings.suffix-LD then "suffix" else "prefix";
+      linkables = filterFlattenUnique sharedLibraries;
+      envVars = FandF_envVarSet environmentVariables;
+      userWrapperArgs = filterFlattenUnique extraWrapperArgs;
+    in pkgs.lib.escapeShellArgs (pkgs.lib.optionals 
+        (settings.configDirName != null && settings.configDirName != "" || settings.configDirName != "nvim") [
+        "--set" "NVIM_APPNAME" settings.configDirName # this sets the name of the folder to look for nvim stuff in
+      ] ++ (pkgs.lib.optionals (pathEnv != []) [
+        "--${preORpostPATH}" "PATH" ":" (pkgs.lib.makeBinPath pathEnv)
+      ]) ++ (pkgs.lib.optionals (linkables != []) [
+        "--${preORpostLD}" "LD_LIBRARY_PATH" ":" (pkgs.lib.makeLibraryPath linkables)
+      ])) + " " + (builtins.concatStringsSep " " (envVars ++ userWrapperArgs));
 
-  normalized = pkgs.callPackage ./normalizePlugins.nix {
-    startup = filterAndFlatten startupPlugins;
-    optional = filterAndFlatten optionalPlugins;
-    inherit (utils) n2l;
-  };
+    python3wrapperArgs = pkgs.lib.unique
+      (pkgs.lib.optionals settings.disablePythonPath ["--unset PYTHONPATH"]
+      ++ (pkgs.lib.optionals settings.disablePythonSafePath ["--unset PYTHONSAFEPATH"])
+      ++ (filterAndFlatten extraPython3wrapperArgs));
 
-  customRC = let
-    optLuaPre = let
-      lua = if builtins.isString optionalLuaPreInit
-        then optionalLuaPreInit
-        else builtins.concatStringsSep "\n"
-        (filterFlattenUnique optionalLuaPreInit);
-    in if lua != "" then "dofile([[${pkgs.writeText "optLuaPre.lua" lua}]])" else "";
-    optLuaAdditions = let
-      lua = if builtins.isString optionalLuaAdditions
-        then optionalLuaAdditions
-        else builtins.concatStringsSep "\n"
-        (filterFlattenUnique optionalLuaAdditions);
-    in if lua != "" then "dofile([[${pkgs.writeText "optLuaAdditions.lua" lua}]])" else "";
-  in /*lua*/''
-    ${pkgs.lib.optionalString (settings.autoconfigure == "prefix" || settings.autoconfigure == true) normalized.passthru_initLua}
-    -- optionalLuaPreInit
-    ${optLuaPre}
-    -- lua from nix with pre = true
-    ${normalized.preInlineConfigs}
-    -- run the init.lua (or init.vim)
-    if vim.fn.filereadable(require('nixCats').configDir .. "/init.lua") == 1 then
-      dofile(require('nixCats').configDir .. "/init.lua")
-    elseif vim.fn.filereadable(require('nixCats').configDir .. "/init.vim") == 1 then
-      vim.cmd.source(require('nixCats').configDir .. "/init.vim")
-    end
-    -- all other lua from nix plugin specs
-    ${normalized.inlineConfigs}
-    -- optionalLuaAdditions
-    ${optLuaAdditions}
-    ${pkgs.lib.optionalString (settings.autoconfigure == "suffix") normalized.passthru_initLua}
-  '';
+    preWrapperShellCode = if builtins.isString bashBeforeWrapper
+      then bashBeforeWrapper
+      else builtins.concatStringsSep "\n" ([/*bash*/''
+        NVIM_WRAPPER_PATH_NIX="$(${pkgs.coreutils}/bin/readlink -f "$0")"
+        export NVIM_WRAPPER_PATH_NIX
+      ''] ++ (filterFlattenUnique bashBeforeWrapper));
 
-  # cat our args
-  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh
-  extraMakeWrapperArgs = let 
-    preORpostPATH = if settings.suffix-path then "suffix" else "prefix";
-    pathEnv = filterFlattenUnique lspsAndRuntimeDeps;
-    preORpostLD = if settings.suffix-LD then "suffix" else "prefix";
-    linkables = filterFlattenUnique sharedLibraries;
-    envVars = FandF_envVarSet environmentVariables;
-    userWrapperArgs = filterFlattenUnique extraWrapperArgs;
-  in pkgs.lib.escapeShellArgs (pkgs.lib.optionals 
-      (settings.configDirName != null && settings.configDirName != "" || settings.configDirName != "nvim") [
-      "--set" "NVIM_APPNAME" settings.configDirName # this sets the name of the folder to look for nvim stuff in
-    ] ++ (pkgs.lib.optionals (pathEnv != []) [
-      "--${preORpostPATH}" "PATH" ":" (pkgs.lib.makeBinPath pathEnv)
-    ]) ++ (pkgs.lib.optionals (linkables != []) [
-      "--${preORpostLD}" "LD_LIBRARY_PATH" ":" (pkgs.lib.makeLibraryPath linkables)
-    ])) + " " + (builtins.concatStringsSep " " (envVars ++ userWrapperArgs));
+    # add our propagated build dependencies
+    baseNvimUnwrapped = if settings.neovim-unwrapped == null then pkgs.neovim-unwrapped else settings.neovim-unwrapped;
+    myNeovimUnwrapped = if settings.nvimSRC != null || buildInputs != [] then baseNvimUnwrapped.overrideAttrs (prev: {
+      src = if settings.nvimSRC != null then settings.nvimSRC else prev.src;
+      propagatedBuildInputs = buildInputs ++ (prev.propagatedBuildInputs or []);
+    }) else baseNvimUnwrapped;
 
-  python3wrapperArgs = pkgs.lib.unique
-    (pkgs.lib.optionals settings.disablePythonPath ["--unset PYTHONPATH"]
-    ++ (pkgs.lib.optionals settings.disablePythonSafePath ["--unset PYTHONSAFEPATH"])
-    ++ (filterAndFlatten extraPython3wrapperArgs));
-
-  preWrapperShellCode = if builtins.isString bashBeforeWrapper
-    then bashBeforeWrapper
-    else builtins.concatStringsSep "\n" ([/*bash*/''
-      NVIM_WRAPPER_PATH_NIX="$(${pkgs.coreutils}/bin/readlink -f "$0")"
-      export NVIM_WRAPPER_PATH_NIX
-    ''] ++ (filterFlattenUnique bashBeforeWrapper));
-
-  # add our propagated build dependencies
-  baseNvimUnwrapped = if settings.neovim-unwrapped == null then pkgs.neovim-unwrapped else settings.neovim-unwrapped;
-  myNeovimUnwrapped = if settings.nvimSRC != null || buildInputs != [] then baseNvimUnwrapped.overrideAttrs (prev: {
-    src = if settings.nvimSRC != null then settings.nvimSRC else prev.src;
-    propagatedBuildInputs = buildInputs ++ (prev.propagatedBuildInputs or []);
-  }) else baseNvimUnwrapped;
-
-  nc_passthru = nixCats_passthru // {
-    keepLuaBuilder = utils.baseBuilder luaPath;
-    nixCats_packageName = name;
-    inherit categoryDefinitions packageDefinitions dependencyOverlays luaPath utils;
-    inherit (settings) moduleNamespace;
-    nixosModule = utils.mkNixosModules {
-      defaultPackageName = name;
-      inherit dependencyOverlays luaPath
-        categoryDefinitions packageDefinitions extra_pkg_config nixpkgs;
+    nc_passthru = (args.nixCats_passthru or {}) // {
+      keepLuaBuilder = utils.baseBuilder luaPath; # why is this still a thing?
+      nixCats_packageName = name;
+      inherit categoryDefinitions packageDefinitions luaPath utils extra_pkg_config extra_pkg_params;
+      dependencyOverlays = pkgs.overlays or [];
       inherit (settings) moduleNamespace;
+      # export nixos module based on this package
+      nixosModule = utils.mkNixosModules {
+        defaultPackageName = name;
+        dependencyOverlays = pkgs.overlays or [];
+        inherit luaPath extra_pkg_config extra_pkg_params
+          categoryDefinitions packageDefinitions;
+        nixpkgs = args.nixpkgs or pkgs.path;
+        inherit (settings) moduleNamespace;
+      };
+      # and the same for home manager
+      homeModule = utils.mkHomeModules {
+        defaultPackageName = name;
+        dependencyOverlays = pkgs.overlays or [];
+        inherit luaPath extra_pkg_config extra_pkg_params
+          categoryDefinitions packageDefinitions;
+        nixpkgs = args.nixpkgs or pkgs.path;
+        inherit (settings) moduleNamespace;
+      };
     };
-    # and the same for home manager
-    homeModule = utils.mkHomeModules {
-      defaultPackageName = name;
-      inherit dependencyOverlays luaPath
-        categoryDefinitions packageDefinitions extra_pkg_config nixpkgs;
-      inherit (settings) moduleNamespace;
+  in {
+    pass = nc_passthru;
+    inherit pkgs;
+    drvargs = import ./wrapNeovim.nix {
+      neovim-unwrapped = myNeovimUnwrapped;
+      nixCats_packageName = name;
+      inherit pkgs extraMakeWrapperArgs nixCats ncTools preWrapperShellCode customRC;
+      inherit (settings) vimAlias viAlias withRuby withPerl extraName withNodeJs aliases gem_path collate_grammars autowrapRuntimeDeps;
+      inherit (normalized) start opt;
+        /* the function you would have passed to python.withPackages */
+      # extraPythonPackages = combineCatsOfFuncs extraPythonPackages;
+        /* the function you would have passed to python.withPackages */
+      withPython3 = settings.withPython3;
+      extraPython3Packages = combineCatsOfFuncs extraPython3Packages;
+      extraPython3wrapperArgs = python3wrapperArgs;
+        /* the function you would have passed to lua.withPackages */
+      extraLuaPackages = combineCatsOfFuncs extraLuaPackages;
     };
   };
-in
-# NOTE: nothing goes past this file that hasnt been sorted
-import ./wrapNeovim.nix {
-  inherit pkgs;
-  neovim-unwrapped = myNeovimUnwrapped;
-  nixCats_passthru = nc_passthru;
-  inherit extraMakeWrapperArgs nixCats ncTools preWrapperShellCode customRC;
-  inherit (settings) vimAlias viAlias withRuby withPerl extraName withNodeJs aliases gem_path collate_grammars autowrapRuntimeDeps;
-  inherit (normalized) start opt;
-    /* the function you would have passed to python.withPackages */
-  # extraPythonPackages = combineCatsOfFuncs extraPythonPackages;
-    /* the function you would have passed to python.withPackages */
-  withPython3 = settings.withPython3;
-  extraPython3Packages = combineCatsOfFuncs extraPython3Packages;
-  extraPython3wrapperArgs = python3wrapperArgs;
-    /* the function you would have passed to lua.withPackages */
-  extraLuaPackages = combineCatsOfFuncs extraLuaPackages;
-}
+
+  mkFinal = args: let
+    processed = process_args args;
+  in processed.pkgs.stdenv.mkDerivation (finalAttrs: let
+    oldargs = {
+      inherit (finalAttrs.passthru) categoryDefinitions packageDefinitions luaPath;
+      name = finalAttrs.passthru.nixCats_packageName;
+      inherit (processed) pkgs;
+    };
+    final_processed = process_args oldargs;
+  in {
+    inherit (final_processed.drvargs) name meta nativeBuildInputs buildPhase __structuredAttrs dontUnpack preferLocalBuild;
+    passthru = processed.pass // {
+      inherit (final_processed.pass) moduleNamespace homeModule nixosModule keepLuaBuilder;
+      dependencyOverlays = builtins.seq final_processed.pass.dependencyOverlays processed.pass.dependencyOverlays;
+      extra_pkg_config = builtins.seq final_processed.pass.extra_pkg_config processed.pass.extra_pkg_config;
+      extra_pkg_params = builtins.seq final_processed.pass.extra_pkg_params processed.pass.extra_pkg_params;
+    };
+  });
+in mkFinal

--- a/builder/wrapNeovim.nix
+++ b/builder/wrapNeovim.nix
@@ -20,7 +20,7 @@
   collate_grammars ? true,
   # the function you would have passed to lua.withPackages
   extraLuaPackages ? (_: [ ]),
-  nixCats_passthru ? { },
+  nixCats_packageName,
   neovim-unwrapped,
   autowrapRuntimeDeps ? "suffix",
 
@@ -105,7 +105,7 @@ in
 (pkgs.callPackage ./wrapper.nix { }) (args // {
   wrapperArgsStr = lib.escapeShellArgs makeWrapperArgs + " " + extraMakeWrapperArgs;
   inherit vimPackDir python3Env luaEnv withNodeJs perlEnv customAliases;
-  inherit (nixCats_passthru) nixCats_packageName;
+  inherit nixCats_packageName;
 } // lib.optionalAttrs withRuby {
   inherit rubyEnv;
 })

--- a/builder/wrapper.nix
+++ b/builder/wrapper.nix
@@ -23,7 +23,6 @@
   , wrapperArgsStr ? ""
   , nixCats_packageName
   , customAliases ? []
-  , nixCats_passthru ? {}
   , preWrapperShellCode ? ""
   , customRC ? ""
   , luaEnv
@@ -100,8 +99,7 @@ let
     ;
 
   preWrapperShellFile = writeText "preNixCatsWrapperShellCode" preWrapperShellCode;
-in
-stdenv.mkDerivation {
+in {
   name = "neovim-${lib.getVersion neovim-unwrapped}-${nixCats_packageName}${lib.optionalString (extraName != "") "-${extraName}"}";
 
   meta = neovim-unwrapped.meta // {
@@ -110,8 +108,6 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-
-  passthru = nixCats_passthru;
 
   __structuredAttrs = true;
   dontUnpack = true;

--- a/nixCatsHelp/nixCats_format.txt
+++ b/nixCatsHelp/nixCats_format.txt
@@ -160,38 +160,7 @@ That is,
     };
 <
                                            *nixCats.flake.outputs.getOverlays*
-We call flake utils to get system variable for all default systems.
-It simply calls the function with each system value, and maps the resulting
-set from { mySet = {}; } to { mySet.${system} = {}; }
-Many overlays require being accessed via ${system} variable in this manner,
-and thus there is a method for handling it in nixCats.
-
-No overlays SHOULD be exported requiring the ${system} variable to access.
-However, some are (such as codeium, a free ai plugin) and thus, we will wrap this anyway.
 >nix
-  inherit (utils.eachSystem nixpkgs.lib.platforms.all (system: let
-                  /* utils.eachSystem is just flake-utils.lib.eachSystem */
-         /* list of overlays from ./overlays is added to the rest of the list */
-    dependencyOverlays = (import ./overlays inputs) ++ [
-      # This overlay grabs all the inputs named in the format
-      # `plugins-<pluginName>`
-      # Once we add this overlay to our nixpkgs, we are able to
-      # use `pkgs.neovimPlugins`, which is a set of our plugins.
-      (utils.standardPluginOverlay inputs)
-      # add any flake overlays here.
-      inputs.neorg-overlay.overlays.default
-      inputs.lz-n.overlays.default
-      # stuff like this is why this part is done this way.
-      inputs.codeium.overlays.${system}.default
-    ];
-    # these overlays will be wrapped with ${system}
-    # and we will call the same utils.eachSystem function
-    # later on to access them.
-  in { inherit dependencyOverlays; })) dependencyOverlays;
-<
-This will allow us to pass system independent overlays to our module options,
-even when importing overlays from improperly formed flakes.
-
 Managing the system variable in combination with overlays
 can be one of the hardest parts of flake usage.
 This flake resolves our pkgs instance for Neovim itself to help with this,
@@ -207,6 +176,9 @@ They could also just be a list of overlays!
     inputs.neorg-overlay.overlays.default
     inputs.lz-n.overlays.default
 
+    # No overlays SHOULD be exported requiring the ${system} variable to access.
+    # However, some are (such as codeium, a free ai plugin)
+
     # when other people mess up their overlays by wrapping them,
     # you may instead call this function on their overlay.
     # it will check if it has the system in it.
@@ -219,50 +191,28 @@ They could also just be a list of overlays!
 <
 
                                                *nixCats.flake.outputs.overlays*
-The two major things of note in this overlays section.
-Regardless of which above method you choose. >nix
-  (utils.standardPluginOverlay inputs) # return type: a single overlay
-  # and
-  (import ./overlays inputs) # type: List of Overlays
-<
-<1>
--- The first to explain is utils.standardPluginOverlay:
-You do not need to edit it to use it.
-Usage of this overlay is described in:
+`utils.standardPluginOverlay`
+Usage of this function to create an overlay is described in:
 :h |nixCats.flake.inputs|
-along with its friend, utils.sanitizedPluginOverlay
+along with its friend, `utils.sanitizedPluginOverlay`
 
 It takes all the inputs named in the format
 `plugins-somepluginname` and makes them into plugins. 
-If the plugin doesn't have a build step,
-and it wasnt on nixpkgs, then use this method.
 Access them to add them to a category of the builder function 
 with `pkgs.neovimPlugins.somepluginname`
 
-<2>
--- The second is overlays/customBuildsOverlay.nix:
+If the plugin doesn't have a build step,
+and it wasnt on nixpkgs, then use this method.
 
-It is imported via overlays/default.nix above
-
-If you need to interact with one of these overlays, it will be this one.
-You should not need to do it much.
-overlays/default.nix imports this overlay and any others like it.
-see :help |nixCats.flake.nixperts.overlays|
-
-It is used for defining plugins with build steps that 
-were not well handled by nixpkgs.
-It is passed flake inputs, and super is pkgs.
-Define the things within the file. 
-Then, access plugins defined there later 
-with 'pkgs.nixCatsBuilds.somepluginname'
+If the plugin does have a build step and isn't on nixpkgs,
+then you can either make your own overlay from scratch,
+or you can call overrideAttrs on the generated plugin
+to add the required items to it.
+more info at :h |nixCats.flake.inputs|
 
 If you decide you wish to split your customBuildsOverlay up, 
 see :help |nixCats.flake.nixperts.overlays|
-or look at the overlays/default.nix file.
-
-<IMPORTANT> When defining your overlays, they will be
-defined in a SEPARATE LIST named <dependencyOverlays>.
-You will need <dependencyOverlays> later.
+or look at the overlays/default.nix file for advice on how to do that.
 
 ---------------------------------------------------------------------------------------
                                             *nixCats.flake.outputs.categories*
@@ -809,10 +759,16 @@ That argument is the name of the Neovim package to be packaged.
 1. The path to the Lua to include (in the flake, we use the self variable to get
      this path and wrap the Lua when `wrapRc = true`)
 
-2. A set containing:
-  The `dependencyOverlays` set or list,
-  extra_pkg_config, nixpkgs, nixCats_passthru, and system so it can
-  resolve pkgs and pass it where it needs to go.
+2. A set containing parameters for the pkgs to be used:
+  It takes 2 forms. You can either pass it a `nixpkgs` and a `system` and it
+  will resolve the `pkgs` for you and pass it to your `categoryDefinitions` and
+  `packageDefinitions`,
+  or you can pass it a `pkgs` instead to inherit the values and do the same.
+
+  You may also provide a `dependencyOverlays` list to add `overlays` for nvim only,
+  `extra_pkg_config` (maps to the config argument to `import nixpkgs { ... }`),
+  `nixCats_passthru` (extra items to put into passthru in the final drv),
+  and `extra_pkg_params` (contains any fields in `import nixpkgs { ... }` not mentioned).
 
 3. our function that takes an individual package definition
      and returns a set of categoryDefinitions.
@@ -821,65 +777,35 @@ That argument is the name of the Neovim package to be packaged.
 
 It is now a function that takes a name, and returns your chosen Neovim package.
 >nix
-  # It requires the system variable to build a package.
-  utils.eachSystem nixpkgs.lib.platforms.all (system: let
+  packages = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: let
     # create our builder for our exports
-    inherit (utils) baseBuilder;
-    nixCatsBuilder = baseBuilder luaPath {
+    nixCatsBuilder = utils.baseBuilder luaPath {
       inherit nixpkgs system dependencyOverlays extra_pkg_config;
     } categoryDefinitions packageDefinitions;
+  in {
     # it can take a name of a package in packageDefinitions
     # and return the package!
-    defaultPackage = nixCatsBuilder defaultPackageName;
-    # ... rest of the outputs section explained
-    # below in :h nixCats.flake.outputs.exports ...
+    default = nixCatsBuilder defaultPackageName;
+  });
 <
-If you use it wrong, you will most likely get this error message:
-
-  The following arguments are accepted:
 >nix
-  # -------------------------------------------------------- #
-
-  # the path to your ~/.config/nvim replacement within your Nix config.
-  luaPath: # <-- must be a store path
-
-  { # set of items for building the pkgs that builds your Neovim
-
-    , nixpkgs # <-- required
-    , system # <-- required
-
-    # type: (attrsOf listOf overlays) or (listOf overlays) or null
-    , dependencyOverlays ? null 
-
-    # import nixpkgs { config = extra_pkg_config; inherit system; }
-    , extra_pkg_config ? {} # type: attrs
-
-    # any extra stuff for finalPackage.passthru
-    , nixCats_passthru ? {} # type: attrs
-  }:
-
-  # type: function with args { pkgs, settings, categories, name, ... }:
-  # returns: set of sets of categories
-  # see :h nixCats.flake.outputs.categories
-  categoryDefinitions: 
-
-  # type: function with args { pkgs, ... }:
-  # returns: { settings = {}; categories = {}; }
-  packageDefinitions: 
-  # see :h nixCats.flake.outputs.packageDefinitions
-  # see :h nixCats.flake.outputs.settings
-
-  # name of the package to built from packageDefinitions
-  name: 
-
-  # -------------------------------------------------------- #
-<
-  # Note:
-  When using override, all values shown above will
-  be top level attributes of prev, none will be nested.
-  i.e. >nix
-  finalPackage.override (prev: { inherit (prev) dependencyOverlays; })
-<      NOT prev.pkgsargs.dependencyOverlays or something like that
+  packages = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: let
+    # create our pkgs to pass to builder
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = dependencyOverlays;
+      config = extra_pkg_config;
+    };
+    # create our builder for our exports
+    nixCatsBuilder = utils.baseBuilder luaPath {
+      /* you can still use dependencyOverlays here and such as well to add */
+      inherit pkgs; # <- but here we are just going to inherit the value.
+    } categoryDefinitions packageDefinitions;
+  in {
+    # it can take a name of a package in packageDefinitions
+    # and return the package!
+    default = nixCatsBuilder defaultPackageName;
+  });
 <
 ---------------------------------------------------------------------------------------
 Flake Exports and Export options               *nixCats.flake.outputs.exports*
@@ -946,6 +872,7 @@ They look something like this:
 
     # we export a NixOS module to allow configuration from configuration.nix
     # allows you to either inherit values from your main flake, or start fresh
+    # It requires the system variable to build a package but not to build a module!
     nixosModules.default = utils.mkNixosModules {
       inherit dependencyOverlays luaPath defaultPackageName
         categoryDefinitions packageDefinitions nixpkgs;

--- a/nixCatsHelp/nixCats_overriding.txt
+++ b/nixCatsHelp/nixCats_overriding.txt
@@ -35,13 +35,14 @@ you could change that here.
     inherit (prev) nixpkgs;
     inherit (prev) system;
     inherit (prev) extra_pkg_config;
+    inherit (prev) extra_pkg_params;
     inherit (prev) nixCats_passthru;
+    pkgs = prev.pkgs or null; # <- might not exist
   };
 <
-This is the full list of attributes you may override:
 
-luaPath categoryDefinitions packageDefinitions name
-nixpkgs system extra_pkg_config dependencyOverlays nixCats_passthru;
+The things you may override are any of the arguments to the main builder
+function, grouped into a single set
 
 ---------------------------------------------------------------------------------
                                                      *nixCats.overriding.name*
@@ -66,60 +67,30 @@ it in the same set, or chain overrides like so:
 <
 ---------------------------------------------------------------------------------
                                        *nixCats.overriding.dependencyOverlays*
-Now we will address the overlays. Overlays can be a list or a set,
-so they are slightly tricky.
-In practice, this is mostly just boilerplate you would get from a template so
-it is not too big of a pain.
 
-This is the same as both of the starter templates,
-we are just using a different function to iterate over systems
-to show more possibilities. It outputs to:
->nix
-  dependencyOverlays.${system} = somelistofoverlays;
-<
-and looks like:
+NixCats provides a function to merge lists of overlays together into a single
+overlay. This allows you to combine overlays that might output to the same
+subattribute without them overwriting each other completely.
+
 >nix
   pkgWithNewOverlays = OGpackage.override (prev: {
-    dependencyOverlays = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all (system: [
-      (utils.mergeOverlayLists
-        (utils.safeOversList { inherit system; inherit (prev) dependencyOverlays; })
-        (/* (import ./overlays inputs) ++ */[
+    dependencyOverlays = [
+      (utils.mergeOverlays
+        (prev.dependencyOverlays ++ [
+          # now pkgs.neovimPlugins will contain
+          # the result of both calls to standardPluginOverlay!
           (utils.standardPluginOverlay inputs)
           # any other flake overlays here.
           inputs.neorg-overlay.overlays.default
           inputs.lz-n.overlays.default
-          inputs.codeium.overlays.${system}.default
+          (utils.fixSystemizedOverlay inputs.codeium.overlays
+            (system: inputs.codeium.overlays.${system}.default)
+          )
         ])
       )
-    ]);
+    ];
   });
 <
-`utils.safeOversList` just checks if `dependencyOverlays` is a list or a set of lists,
-and always returns a list
-
-OR
-as just a list, fixing improper overlays via helper function:
->nix
-  pkgWithNewOverlays = OGpackage.override (prev: {
-    dependencyOverlays = [ (utils.mergeOverlayLists
-      (utils.safeOversList { inherit (prev) system dependencyOverlays; })
-      (/* (import ./overlays inputs) ++ */[
-        (utils.standardPluginOverlay inputs)
-        # any other flake overlays here.
-        inputs.neorg-overlay.overlays.default
-        inputs.lz-n.overlays.default
-        # to fix systematized overlay sets
-        (utils.fixSystemizedOverlay inputs.codeium.overlays
-          (system: inputs.codeium.overlays.${system}.default)
-        )
-      ])
-    ) ];
-  });
-<
- If you always choose the list option, it will always be
-a list from then on and thus no need for `utils.safeOversList`,
-but you still will need `utils.mergeOverlayLists` to merge overlays.
-
 ---------------------------------------------------------------------------------
                                       *nixCats.overriding.categoryDefinitions*
 In our `categoryDefinitions`, we most likely also want our new overlays.

--- a/templates/LazyVim/flake.nix
+++ b/templates/LazyVim/flake.nix
@@ -45,11 +45,6 @@
     # this allows you to use ${pkgs.system} whenever you want in those sections
     # without fear.
 
-    # sometimes our overlays require a ${system} to access the overlay.
-    # Your dependencyOverlays can either be lists
-    # in a set of ${system}, or simply a list.
-    # the nixCats builder function will accept either.
-    # see :help nixCats.flake.outputs.overlays
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
       # This overlay grabs all the inputs named in the format
       # `plugins-<pluginName>`

--- a/templates/example/flake.lock
+++ b/templates/example/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixCats": {
       "locked": {
-        "lastModified": 1741980020,
-        "narHash": "sha256-eB+p7Uq0Hz57Uvi4q+lV7Oxft1yK4SaPs9syPfO+9WY=",
+        "lastModified": 1742124230,
+        "narHash": "sha256-jrRa54JiOfGoRjPtppaisCe/hDNhyPTLq6j0I88wMtw=",
         "owner": "BirdeeHub",
         "repo": "nixCats-nvim",
-        "rev": "b4c0ba43124cd822fb1d4178d70a3f0096d69034",
+        "rev": "32fbe1471e58b9bc3f98e34aee422fc04bb0d624",
         "type": "github"
       },
       "original": {

--- a/templates/example/flake.nix
+++ b/templates/example/flake.nix
@@ -73,10 +73,6 @@
     # this allows you to use ${pkgs.system} whenever you want in those sections
     # without fear.
 
-    # sometimes our overlays require a ${system} to access the overlay.
-    # Your dependencyOverlays can either be lists
-    # in a set of ${system}, or simply a list.
-    # the nixCats builder function will accept either.
     # see :help nixCats.flake.outputs.overlays
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
       # This overlay grabs all the inputs named in the format

--- a/templates/flakeless/default.nix
+++ b/templates/flakeless/default.nix
@@ -10,16 +10,6 @@
   utils = import nixCats;
   # path to your new .config/nvim
   luaPath = ./.;
-  # the following extra_pkg_config contains any values
-  # which you want to pass to the config set of nixpkgs
-  # import nixpkgs { config = extra_pkg_config; inherit system; }
-  # will not apply to module imports
-  # as that will have your system values
-  extra_pkg_config = {
-    # allowUnfree = true;
-  };
-  # will apply to only nvim
-  dependencyOverlays = /* pkgs.overlays ++ */ [];
 
   # see :help nixCats.flake.outputs.categories
   categoryDefinitions = { pkgs, settings, categories, extra, name, mkNvimPlugin, ... }@packageDef: {
@@ -122,8 +112,4 @@
   defaultPackageName = "nvim";
 
 # return our package!
-in utils.baseBuilder luaPath {
-  inherit dependencyOverlays extra_pkg_config;
-  inherit (pkgs) system;
-  nixpkgs = pkgs; # <- accepts pkgs, <nixpkgs>, inputs.nixpkgs, or pkgs.path
-} categoryDefinitions packageDefinitions defaultPackageName
+in utils.baseBuilder luaPath { inherit pkgs; } categoryDefinitions packageDefinitions defaultPackageName

--- a/templates/fresh/flake.nix
+++ b/templates/fresh/flake.nix
@@ -62,10 +62,6 @@
     # this allows you to use ${pkgs.system} whenever you want in those sections
     # without fear.
 
-    # sometimes our overlays require a ${system} to access the overlay.
-    # Your dependencyOverlays can either be lists
-    # in a set of ${system}, or simply a list.
-    # the nixCats builder function will accept either.
     # see :help nixCats.flake.outputs.overlays
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
       # This overlay grabs all the inputs named in the format

--- a/templates/kickstart-nvim/flake.nix
+++ b/templates/kickstart-nvim/flake.nix
@@ -62,11 +62,6 @@
     # this allows you to use ${pkgs.system} whenever you want in those sections
     # without fear.
 
-    # sometimes our overlays require a ${system} to access the overlay.
-    # Your dependencyOverlays can either be lists
-    # in a set of ${system}, or simply a list.
-    # the nixCats builder function will accept either.
-    # see :help nixCats.flake.outputs.overlays
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
       # This overlay grabs all the inputs named in the format
       # `plugins-<pluginName>`

--- a/templates/nixExpressionFlakeOutputs/default.nix
+++ b/templates/nixExpressionFlakeOutputs/default.nix
@@ -26,8 +26,6 @@
   # the following extra_pkg_config contains any values
   # which you want to pass to the config set of nixpkgs
   # import nixpkgs { config = extra_pkg_config; inherit system; }
-  # will not apply to module imports
-  # as that will have your system values
   extra_pkg_config = {
     # allowUnfree = true;
   };

--- a/templates/overriding/flake.nix
+++ b/templates/overriding/flake.nix
@@ -48,24 +48,14 @@
         inherit (prev) extra_pkg_config;
         inherit (prev) nixCats_passthru;
 
-        # and our dependencyOverlays by system.
-        # we didnt add any extra here but this is to demonstrate
-        # that it is the same as any other templates,
-        # we are just using a different function to iterate over systems
-        # to show more possibilities. it outputs to:
-        # dependencyOverlays.${system} = somelistofoverlays;
-        # just like normal.
-        # utils.safeOversList just checks if dependencyOverlays is a list or a set of lists,
-        # and always returns a list
-        dependencyOverlays = forSystems (system: [
+        dependencyOverlays = [
           (utils.mergeOverlays
-            ((utils.safeOversList { inherit system; inherit (prev) dependencyOverlays; }) ++
-            /* (import ./overlays inputs) ++ */[
+            (prev.dependencyOverlays ++ [
               (utils.standardPluginOverlay inputs)
               # any other flake overlays here.
             ])
           )
-        ]);
+        ];
       });
 
       # you can call override many times. We could have also have done this all in 1 call.

--- a/templates/overwrite/flake.nix
+++ b/templates/overwrite/flake.nix
@@ -48,13 +48,10 @@
         };
         nixCats_passthru = {};
 
-        # dependencyOverlays.${system} = [ (final: prev: {}) ];
-        dependencyOverlays = forSystems (system: (
-          /* (import ./overlays inputs) ++ */ [
-            (utils.standardPluginOverlay inputs)
-            # other overlays
-          ]
-        ));
+        dependencyOverlays = [
+          (utils.standardPluginOverlay inputs)
+          # other overlays
+        ];
 
         categoryDefinitions = { pkgs, settings, categories, extra, name, mkNvimPlugin, ... }@packageDef: {
           # NOTE: for all available fields, see:

--- a/utils/lib.nix
+++ b/utils/lib.nix
@@ -77,4 +77,60 @@ with builtins; rec {
       );
   in f [] [rhs lhs];
 
+  functionArgs = f:
+    if f ? __functor
+    then f.__functionArgs or (functionArgs (f.__functor f))
+    else builtins.functionArgs f;
+  setFunctionArgs = f: args:
+    {
+      __functor = self: f;
+      __functionArgs = args;
+    };
+  mirrorFunctionArgs = f: let
+    fArgs = functionArgs f;
+  in
+  g: setFunctionArgs g fArgs;
+
+  # modified to add an extra overrideNixCats value that
+  # works the same as override but wont be shadowed by callPackage
+  makeOverridable = overrideDerivation:
+    f:
+    let
+      mkOver = makeOverridable overrideDerivation;
+      # Creates a functor with the same arguments as f
+      mirrorArgs = mirrorFunctionArgs f;
+    in
+    mirrorArgs (
+      origArgs:
+      let
+        result = f origArgs;
+
+        # Changes the original arguments with (potentially a function that returns) a set of new attributes
+        overrideWith = newArgs: origArgs // (if isFunction newArgs then newArgs origArgs else newArgs);
+
+        # Re-call the function but with different arguments
+        overrideArgs = mirrorArgs (newArgs: mkOver f (overrideWith newArgs));
+        # Change the result of the function call by applying g to it
+        overrideResult = g: mkOver (mirrorArgs (args: g (f args))) origArgs;
+      in
+      if isAttrs result then
+        result
+        // {
+          override = overrideArgs;
+          overrideNixCats = overrideArgs;
+          overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
+          ${if result ? overrideAttrs then "overrideAttrs" else null} =
+            fdrv: overrideResult (x: x.overrideAttrs fdrv);
+        }
+      else if isFunction result then
+        # Transform the result into a functor while propagating its arguments
+        setFunctionArgs result (functionArgs result)
+        // {
+          override = overrideArgs;
+          overrideNixCats = overrideArgs;
+        }
+      else
+        result
+    );
+
 }

--- a/utils/mkOpts.nix
+++ b/utils/mkOpts.nix
@@ -18,451 +18,451 @@ in {
 
   options = with lib; lib.setAttrByPath moduleNamespace ({
 
-      nixpkgs_version = mkOption {
+    nixpkgs_version = mkOption {
+      default = null;
+      type = types.nullOr (types.anything);
+      description = ''
+        a different nixpkgs import to use. By default will use the one from the flake, or system pkgs.
+      '';
+      example = ''
+        nixpkgs_version = inputs.nixpkgs
+      '';
+    };
+
+    addOverlays = mkOption {
+      default = [];
+      type = (types.listOf types.anything);
+      description = ''
+        A list of overlays to make available to any nixCats package from this module but not to your system.
+        Will have access to system overlays regardless of this setting.
+      '';
+      example = ''
+        addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+      '';
+    };
+
+    enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Enable the ${concatStringsSep "." moduleNamespace} module";
+    };
+
+    dontInstall = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        If true, do not output to packages list,
+        output only to config.${concatStringsSep "." moduleNamespace}.out
+      '';
+    };
+
+    luaPath = mkOption {
+      default = luaPath;
+      type = types.oneOf [ types.str types.path types.package ];
+      description = ''
+        The path to your nvim config directory in the store.
+        In templates, this is "./."
+      '';
+      example = ''./nvim'';
+    };
+
+    packageNames = mkOption {
+      default = if defaultPackageName != null && packageDefinitions ? "${defaultPackageName}" then [ defaultPackageName ] else [];
+      type = (types.listOf types.str);
+      description = ''A list of packages from packageDefinitions to include'';
+      example = ''
+        packageNames = [ "nixCats" ]
+      '';
+    };
+
+    categoryDefinitions = {
+      existing = mkOption {
+        default = "replace";
+        type = types.enum [ "replace" "merge" "discard" ];
+        description = ''
+          the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+          choose between "replace", "merge" or "discard"
+          replace uses utils.mergeCatDefs
+          merge uses utils.deepmergeCats
+          discard does not inherit
+          see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+        '';
+      };
+      replace = mkOption {
         default = null;
-        type = types.nullOr (types.anything);
+        type = types.nullOr (catDef "replace");
         description = ''
-          a different nixpkgs import to use. By default will use the one from the flake, or system pkgs.
+          see :help nixCats.flake.outputs.categories
+          uses utils.mergeCatDefs to recursively update old categories with new values
+          see :help nixCats.flake.outputs.exports for more info on the merge strategy options
         '';
         example = ''
-          nixpkgs_version = inputs.nixpkgs
+          # see :help nixCats.flake.outputs.categories
+          categoryDefinitions.replace = { pkgs, settings, categories, name, ... }@packageDef: { }
         '';
       };
-
-      addOverlays = mkOption {
-        default = [];
-        type = (types.listOf types.anything);
-        description = ''
-          A list of overlays to make available to any nixCats package from this module but not to your system.
-          Will have access to system overlays regardless of this setting.
-        '';
-        example = ''
-          addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
-        '';
-      };
-
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Enable the ${concatStringsSep "." moduleNamespace} module";
-      };
-
-      dontInstall = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          If true, do not output to packages list,
-          output only to config.${concatStringsSep "." moduleNamespace}.out
-        '';
-      };
-
-      luaPath = mkOption {
-        default = luaPath;
-        type = types.oneOf [ types.str types.path types.package ];
-        description = ''
-          The path to your nvim config directory in the store.
-          In templates, this is "./."
-        '';
-        example = ''./nvim'';
-      };
-
-      packageNames = mkOption {
-        default = if defaultPackageName != null && packageDefinitions ? "${defaultPackageName}" then [ defaultPackageName ] else [];
-        type = (types.listOf types.str);
-        description = ''A list of packages from packageDefinitions to include'';
-        example = ''
-          packageNames = [ "nixCats" ]
-        '';
-      };
-
-      categoryDefinitions = {
-        existing = mkOption {
-          default = "replace";
-          type = types.enum [ "replace" "merge" "discard" ];
-          description = ''
-            the merge strategy to use for categoryDefinitions inherited from the package this module was based on
-            choose between "replace", "merge" or "discard"
-            replace uses utils.mergeCatDefs
-            merge uses utils.deepmergeCats
-            discard does not inherit
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-          '';
-        };
-        replace = mkOption {
-          default = null;
-          type = types.nullOr (catDef "replace");
-          description = ''
-            see :help nixCats.flake.outputs.categories
-            uses utils.mergeCatDefs to recursively update old categories with new values
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-          '';
-          example = ''
-            # see :help nixCats.flake.outputs.categories
-            categoryDefinitions.replace = { pkgs, settings, categories, name, ... }@packageDef: { }
-          '';
-        };
-        merge = mkOption {
-          default = null;
-          type = types.nullOr (catDef "merge");
-          description = ''
-            see :help nixCats.flake.outputs.categories
-            uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-          '';
-          example = ''
-            # see :help nixCats.flake.outputs.categories
-            categoryDefinitions.merge = { pkgs, settings, categories, name, ... }@packageDef: { }
-          '';
-        };
-      };
-
-      packages = mkOption {
+      merge = mkOption {
         default = null;
-        type = with types; nullOr (attrsOf (catDef "replace"));
-        visible = false;
+        type = types.nullOr (catDef "merge");
+        description = ''
+          see :help nixCats.flake.outputs.categories
+          uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
+          see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+        '';
+        example = ''
+          # see :help nixCats.flake.outputs.categories
+          categoryDefinitions.merge = { pkgs, settings, categories, name, ... }@packageDef: { }
+        '';
       };
+    };
 
-      packageDefinitions = {
-        existing = mkOption {
-          default = "replace";
-          type = types.enum [ "replace" "merge" "discard" ];
-          description = ''
-            the merge strategy to use for packageDefinitions inherited from the package this module was based on
-            choose between "replace", "merge" or "discard"
-            replace uses utils.mergeCatDefs
-            merge uses utils.deepmergeCats
-            discard does not inherit
-            see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-          '';
-        };
-        merge = mkOption {
-          default = null;
-          description = ''
-            VERY IMPORTANT when setting aliases for each package,
-            they must not be the same as ANY other neovim package for that user.
-            It will cause a build conflict.
+    packages = mkOption {
+      default = null;
+      type = with types; nullOr (attrsOf (catDef "replace"));
+      visible = false;
+    };
 
-            You can have as many nixCats installed per user as you want,
-            as long as you obey that rule.
+    packageDefinitions = {
+      existing = mkOption {
+        default = "replace";
+        type = types.enum [ "replace" "merge" "discard" ];
+        description = ''
+          the merge strategy to use for packageDefinitions inherited from the package this module was based on
+          choose between "replace", "merge" or "discard"
+          replace uses utils.mergeCatDefs
+          merge uses utils.deepmergeCats
+          discard does not inherit
+          see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+        '';
+      };
+      merge = mkOption {
+        default = null;
+        description = ''
+          VERY IMPORTANT when setting aliases for each package,
+          they must not be the same as ANY other neovim package for that user.
+          It will cause a build conflict.
 
-            for information on the values you may return,
-            see :help nixCats.flake.outputs.settings
-            and :help nixCats.flake.outputs.categories
-          '';
-          type = with types; nullOr (attrsOf (pkgDef "merge"));
-          example = ''
-            packageDefinitions.merge = { 
-              nixCats = { pkgs, ... }: {
-                settings = {
-                  wrapRc = true;
-                  configDirName = "nixCats-nvim";
-                  # nvimSRC = inputs.neovim;
-                  aliases = [ "vim" "nixCats" ];
-                };
-                categories = {
-                  generalBuildInputs = true;
-                  markdown = true;
-                  gitPlugins = true;
-                  general = true;
-                  custom = true;
-                  neonixdev = true;
-                  debug = false;
-                  test = true;
-                  lspDebugMode = false;
-                  themer = true;
-                  colorscheme = "onedark";
-                };
+          You can have as many nixCats installed per user as you want,
+          as long as you obey that rule.
+
+          for information on the values you may return,
+          see :help nixCats.flake.outputs.settings
+          and :help nixCats.flake.outputs.categories
+        '';
+        type = with types; nullOr (attrsOf (pkgDef "merge"));
+        example = ''
+          packageDefinitions.merge = { 
+            nixCats = { pkgs, ... }: {
+              settings = {
+                wrapRc = true;
+                configDirName = "nixCats-nvim";
+                # nvimSRC = inputs.neovim;
+                aliases = [ "vim" "nixCats" ];
               };
-            }
-          '';
-        };
-        replace = mkOption {
-          default = null;
-          description = ''
-            VERY IMPORTANT when setting aliases for each package,
-            they must not be the same as ANY other neovim package for that user.
-            It will cause a build conflict.
-
-            You can have as many nixCats installed per user as you want,
-            as long as you obey that rule.
-
-            for information on the values you may return,
-            see :help nixCats.flake.outputs.settings
-            and :help nixCats.flake.outputs.categories
-          '';
-          type = with types; nullOr (attrsOf (pkgDef "replace"));
-          example = ''
-            packageDefinitions.replace = { 
-              nixCats = { pkgs, ... }: {
-                settings = {
-                  wrapRc = true;
-                  configDirName = "nixCats-nvim";
-                  # nvimSRC = inputs.neovim;
-                  aliases = [ "vim" "nixCats" ];
-                };
-                categories = {
-                  generalBuildInputs = true;
-                  markdown = true;
-                  gitPlugins = true;
-                  general = true;
-                  custom = true;
-                  neonixdev = true;
-                  debug = false;
-                  test = true;
-                  lspDebugMode = false;
-                  themer = true;
-                  colorscheme = "onedark";
-                };
-              };
-            }
-          '';
-        };
-      };
-
-      utils = mkOption {
-        type = types.attrsOf types.anything;
-        readOnly = true;
-        description = "[nixCats utils set](https://nixcats.org/nixCats_utils.html)";
-      };
-
-      out = {
-        packages = mkOption {
-          type = types.attrsOf types.package;
-          readOnly = true;
-          description = "Resulting customized neovim packages.";
-        };
-      } // (lib.optionalAttrs (! isHomeManager) {
-        users = mkOption {
-          description = ''
-            Resulting customized neovim packages for users.
-          '';
-          readOnly = true;
-          type = with types; attrsOf (submodule {
-            options = {
-              packages = mkOption {
-                type = types.attrsOf types.package;
-                readOnly = true;
-                description = "Resulting customized neovim packages for this user";
+              categories = {
+                generalBuildInputs = true;
+                markdown = true;
+                gitPlugins = true;
+                general = true;
+                custom = true;
+                neonixdev = true;
+                debug = false;
+                test = true;
+                lspDebugMode = false;
+                themer = true;
+                colorscheme = "onedark";
               };
             };
-          });
-        };
-      });
-
-    } // (lib.optionalAttrs (! isHomeManager) {
-
-      users = mkOption {
-        default = {};
-        description = ''
-          same as system config but per user instead
+          }
         '';
+      };
+      replace = mkOption {
+        default = null;
+        description = ''
+          VERY IMPORTANT when setting aliases for each package,
+          they must not be the same as ANY other neovim package for that user.
+          It will cause a build conflict.
+
+          You can have as many nixCats installed per user as you want,
+          as long as you obey that rule.
+
+          for information on the values you may return,
+          see :help nixCats.flake.outputs.settings
+          and :help nixCats.flake.outputs.categories
+        '';
+        type = with types; nullOr (attrsOf (pkgDef "replace"));
+        example = ''
+          packageDefinitions.replace = { 
+            nixCats = { pkgs, ... }: {
+              settings = {
+                wrapRc = true;
+                configDirName = "nixCats-nvim";
+                # nvimSRC = inputs.neovim;
+                aliases = [ "vim" "nixCats" ];
+              };
+              categories = {
+                generalBuildInputs = true;
+                markdown = true;
+                gitPlugins = true;
+                general = true;
+                custom = true;
+                neonixdev = true;
+                debug = false;
+                test = true;
+                lspDebugMode = false;
+                themer = true;
+                colorscheme = "onedark";
+              };
+            };
+          }
+        '';
+      };
+    };
+
+    utils = mkOption {
+      type = types.attrsOf types.anything;
+      readOnly = true;
+      description = "[nixCats utils set](https://nixcats.org/nixCats_utils.html)";
+    };
+
+    out = {
+      packages = mkOption {
+        type = types.attrsOf types.package;
+        readOnly = true;
+        description = "Resulting customized neovim packages.";
+      };
+    } // (lib.optionalAttrs (! isHomeManager) {
+      users = mkOption {
+        description = ''
+          Resulting customized neovim packages for users.
+        '';
+        readOnly = true;
         type = with types; attrsOf (submodule {
           options = {
-            enable = mkOption {
-              default = false;
-              type = types.bool;
-              description = "Enable the ${concatStringsSep "." moduleNamespace}.users module for a user";
-            };
-
-            dontInstall = mkOption {
-              default = false;
-              type = types.bool;
-              description = ''
-                If true, do not output to packages list,
-                output only to config.${concatStringsSep "." moduleNamespace}.out.users
-              '';
-            };
-
-            nixpkgs_version = mkOption {
-              default = null;
-              type = types.nullOr (types.anything);
-              description = ''
-                a different nixpkgs import to use for this users nvim.
-                By default will use the one from ${concatStringsSep "." moduleNamespace}.nixpkgs_version, or flake, or system pkgs.
-              '';
-              example = ''
-                nixpkgs_version = inputs.nixpkgs
-              '';
-            };
-
-            addOverlays = mkOption {
-              default = [];
-              type = (types.listOf types.anything);
-              description = ''
-                A list of overlays to make available to
-                this user's nixCats packages from this module but not to your system.
-                Will have access to system overlays regardless of this setting.
-                This per user version of addOverlays is merged with the value of ${concatStringsSep "." moduleNamespace}.addOverlays 
-              '';
-              example = ''
-                addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
-              '';
-            };
-
-            luaPath = mkOption {
-              default = luaPath;
-              type = types.oneOf [ types.str types.path types.package ];
-              description = ''
-                The path to your nvim config directory in the store.
-                In templates, this is "./."
-              '';
-              example = ''./user_nvim'';
-            };
-
-            packageNames = mkOption {
-              default = if defaultPackageName != null && packageDefinitions ? "${defaultPackageName}" then [ defaultPackageName ] else [];
-              type = (types.listOf types.str);
-              description = ''A list of packages from packageDefinitions to include'';
-              example = ''
-                packageNames = [ "nixCats" ]
-              '';
-            };
-
-            categoryDefinitions = {
-              existing = mkOption {
-                default = "replace";
-                type = types.enum [ "replace" "merge" "discard" ];
-                description = ''
-                  the merge strategy to use for categoryDefinitions inherited from the package this module was based on
-                  choose between "replace", "merge" or "discard"
-                  replace uses utils.mergeCatDefs
-                  merge uses utils.deepmergeCats
-                  discard does not inherit
-                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-                '';
-              };
-              replace = mkOption {
-                default = null;
-                type = types.nullOr (catDef "replace");
-                description = ''
-                  see :help nixCats.flake.outputs.categories
-                  uses utils.mergeCatDefs to recursively update old categories with new values
-                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-                '';
-                example = ''
-                  categoryDefinitions.replace = { pkgs, settings, categories, name, extra, mkNvimPlugin, ... }@packageDef: { }
-                '';
-              };
-              merge = mkOption {
-                default = null;
-                type = types.nullOr (catDef "merge");
-                description = ''
-                  see :help nixCats.flake.outputs.categories
-                  uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
-                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-                '';
-                example = ''
-                  categoryDefinitions.merge = { pkgs, settings, categories, name, extra, mkNvimPlugin, ... }@packageDef: { }
-                '';
-              };
-            };
-
             packages = mkOption {
-              default = null;
-              type = with types; nullOr (attrsOf (catDef "replace"));
-              visible = false;
+              type = types.attrsOf types.package;
+              readOnly = true;
+              description = "Resulting customized neovim packages for this user";
             };
-
-            packageDefinitions = {
-              existing = mkOption {
-                default = "replace";
-                type = types.enum [ "replace" "merge" "discard" ];
-                description = ''
-                  the merge strategy to use for categoryDefinitions inherited from the package this module was based on
-                  choose between "replace", "merge" or "discard"
-                  replace uses utils.mergeCatDefs
-                  merge uses utils.deepmergeCats
-                  discard does not inherit
-                  see :help nixCats.flake.outputs.exports for more info on the merge strategy options
-                '';
-              };
-              merge = mkOption {
-                default = null;
-                description = ''
-                  VERY IMPORTANT when setting aliases for each package,
-                  they must not be the same as ANY other neovim package for that user.
-                  It will cause a build conflict.
-
-                  You can have as many nixCats installed per user as you want,
-                  as long as you obey that rule.
-
-                  for information on the values you may return,
-                  see :help nixCats.flake.outputs.settings
-                  and :help nixCats.flake.outputs.categories
-                '';
-                type = with types; nullOr (attrsOf (pkgDef "merge"));
-                example = ''
-                  nixCats.users.<USER>.packageDefinitions.merge = { 
-                    nixCats = { pkgs, ... }: {
-                      settings = {
-                        wrapRc = true;
-                        configDirName = "nixCats-nvim";
-                        # nvimSRC = inputs.neovim;
-                        aliases = [ "vim" "nixCats" ];
-                      };
-                      categories = {
-                        generalBuildInputs = true;
-                        markdown = true;
-                        gitPlugins = true;
-                        general = true;
-                        custom = true;
-                        neonixdev = true;
-                        debug = false;
-                        test = true;
-                        lspDebugMode = false;
-                        themer = true;
-                        colorscheme = "onedark";
-                      };
-                    };
-                  }
-                '';
-              };
-              replace = mkOption {
-                default = null;
-                description = ''
-                  VERY IMPORTANT when setting aliases for each package,
-                  they must not be the same as ANY other neovim package for that user.
-                  It will cause a build conflict.
-
-                  You can have as many nixCats installed per user as you want,
-                  as long as you obey that rule.
-
-                  for information on the values you may return,
-                  see :help nixCats.flake.outputs.settings
-                  and :help nixCats.flake.outputs.categories
-                '';
-                type = with types; nullOr (attrsOf (pkgDef "replace"));
-                example = ''
-                  nixCats.users.<USER>.packageDefinitions.replace = { 
-                    nixCats = { pkgs, ... }: {
-                      settings = {
-                        wrapRc = true;
-                        configDirName = "nixCats-nvim";
-                        # nvimSRC = inputs.neovim;
-                        aliases = [ "vim" "nixCats" ];
-                      };
-                      categories = {
-                        generalBuildInputs = true;
-                        markdown = true;
-                        gitPlugins = true;
-                        general = true;
-                        custom = true;
-                        neonixdev = true;
-                        debug = false;
-                        test = true;
-                        lspDebugMode = false;
-                        themer = true;
-                        colorscheme = "onedark";
-                      };
-                    };
-                  }
-                '';
-              };
-            };
-
           };
         });
       };
-    }));
+    });
+
+  } // (lib.optionalAttrs (! isHomeManager) {
+
+    users = mkOption {
+      default = {};
+      description = ''
+        same as system config but per user instead
+      '';
+      type = with types; attrsOf (submodule {
+        options = {
+          enable = mkOption {
+            default = false;
+            type = types.bool;
+            description = "Enable the ${concatStringsSep "." moduleNamespace}.users module for a user";
+          };
+
+          dontInstall = mkOption {
+            default = false;
+            type = types.bool;
+            description = ''
+              If true, do not output to packages list,
+              output only to config.${concatStringsSep "." moduleNamespace}.out.users
+            '';
+          };
+
+          nixpkgs_version = mkOption {
+            default = null;
+            type = types.nullOr (types.anything);
+            description = ''
+              a different nixpkgs import to use for this users nvim.
+              By default will use the one from ${concatStringsSep "." moduleNamespace}.nixpkgs_version, or flake, or system pkgs.
+            '';
+            example = ''
+              nixpkgs_version = inputs.nixpkgs
+            '';
+          };
+
+          addOverlays = mkOption {
+            default = [];
+            type = (types.listOf types.anything);
+            description = ''
+              A list of overlays to make available to
+              this user's nixCats packages from this module but not to your system.
+              Will have access to system overlays regardless of this setting.
+              This per user version of addOverlays is merged with the value of ${concatStringsSep "." moduleNamespace}.addOverlays 
+            '';
+            example = ''
+              addOverlays = [ (self: super: { nvimPlugins = { pluginDerivationName = pluginDerivation; }; }) ]
+            '';
+          };
+
+          luaPath = mkOption {
+            default = luaPath;
+            type = types.oneOf [ types.str types.path types.package ];
+            description = ''
+              The path to your nvim config directory in the store.
+              In templates, this is "./."
+            '';
+            example = ''./user_nvim'';
+          };
+
+          packageNames = mkOption {
+            default = if defaultPackageName != null && packageDefinitions ? "${defaultPackageName}" then [ defaultPackageName ] else [];
+            type = (types.listOf types.str);
+            description = ''A list of packages from packageDefinitions to include'';
+            example = ''
+              packageNames = [ "nixCats" ]
+            '';
+          };
+
+          categoryDefinitions = {
+            existing = mkOption {
+              default = "replace";
+              type = types.enum [ "replace" "merge" "discard" ];
+              description = ''
+                the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+                choose between "replace", "merge" or "discard"
+                replace uses utils.mergeCatDefs
+                merge uses utils.deepmergeCats
+                discard does not inherit
+                see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+              '';
+            };
+            replace = mkOption {
+              default = null;
+              type = types.nullOr (catDef "replace");
+              description = ''
+                see :help nixCats.flake.outputs.categories
+                uses utils.mergeCatDefs to recursively update old categories with new values
+                see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+              '';
+              example = ''
+                categoryDefinitions.replace = { pkgs, settings, categories, name, extra, mkNvimPlugin, ... }@packageDef: { }
+              '';
+            };
+            merge = mkOption {
+              default = null;
+              type = types.nullOr (catDef "merge");
+              description = ''
+                see :help nixCats.flake.outputs.categories
+                uses utils.deepmergeCats to recursively update and merge category lists if duplicates are defined
+                see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+              '';
+              example = ''
+                categoryDefinitions.merge = { pkgs, settings, categories, name, extra, mkNvimPlugin, ... }@packageDef: { }
+              '';
+            };
+          };
+
+          packages = mkOption {
+            default = null;
+            type = with types; nullOr (attrsOf (catDef "replace"));
+            visible = false;
+          };
+
+          packageDefinitions = {
+            existing = mkOption {
+              default = "replace";
+              type = types.enum [ "replace" "merge" "discard" ];
+              description = ''
+                the merge strategy to use for categoryDefinitions inherited from the package this module was based on
+                choose between "replace", "merge" or "discard"
+                replace uses utils.mergeCatDefs
+                merge uses utils.deepmergeCats
+                discard does not inherit
+                see :help nixCats.flake.outputs.exports for more info on the merge strategy options
+              '';
+            };
+            merge = mkOption {
+              default = null;
+              description = ''
+                VERY IMPORTANT when setting aliases for each package,
+                they must not be the same as ANY other neovim package for that user.
+                It will cause a build conflict.
+
+                You can have as many nixCats installed per user as you want,
+                as long as you obey that rule.
+
+                for information on the values you may return,
+                see :help nixCats.flake.outputs.settings
+                and :help nixCats.flake.outputs.categories
+              '';
+              type = with types; nullOr (attrsOf (pkgDef "merge"));
+              example = ''
+                nixCats.users.<USER>.packageDefinitions.merge = { 
+                  nixCats = { pkgs, ... }: {
+                    settings = {
+                      wrapRc = true;
+                      configDirName = "nixCats-nvim";
+                      # nvimSRC = inputs.neovim;
+                      aliases = [ "vim" "nixCats" ];
+                    };
+                    categories = {
+                      generalBuildInputs = true;
+                      markdown = true;
+                      gitPlugins = true;
+                      general = true;
+                      custom = true;
+                      neonixdev = true;
+                      debug = false;
+                      test = true;
+                      lspDebugMode = false;
+                      themer = true;
+                      colorscheme = "onedark";
+                    };
+                  };
+                }
+              '';
+            };
+            replace = mkOption {
+              default = null;
+              description = ''
+                VERY IMPORTANT when setting aliases for each package,
+                they must not be the same as ANY other neovim package for that user.
+                It will cause a build conflict.
+
+                You can have as many nixCats installed per user as you want,
+                as long as you obey that rule.
+
+                for information on the values you may return,
+                see :help nixCats.flake.outputs.settings
+                and :help nixCats.flake.outputs.categories
+              '';
+              type = with types; nullOr (attrsOf (pkgDef "replace"));
+              example = ''
+                nixCats.users.<USER>.packageDefinitions.replace = { 
+                  nixCats = { pkgs, ... }: {
+                    settings = {
+                      wrapRc = true;
+                      configDirName = "nixCats-nvim";
+                      # nvimSRC = inputs.neovim;
+                      aliases = [ "vim" "nixCats" ];
+                    };
+                    categories = {
+                      generalBuildInputs = true;
+                      markdown = true;
+                      gitPlugins = true;
+                      general = true;
+                      custom = true;
+                      neonixdev = true;
+                      debug = false;
+                      test = true;
+                      lspDebugMode = false;
+                      themer = true;
+                      colorscheme = "onedark";
+                    };
+                  };
+                }
+              '';
+            };
+          };
+
+        };
+      });
+    };
+  }));
 
 }


### PR DESCRIPTION
Added `.overrideNixCats` alias for `.override`
to avoid it being shadowed by `callPackage`

Allowed overriding of select passthru values via overrideAttrs to change the args to the builder function.

allowed pkgs to be passed to main builder function instead of nixpkgs and system arguments
and inherit overlays and other attributes from it.

This allows flakeless users to avoid reinstantiating nixpkgs.

deprecated being able to pass a system wrapped set of lists instead of just a list as dependencyOverlays, something that is not recommended, as overlays already can access the system variable internally.