### PR TITLE
Note enabling `hosts.python` after setting `python3.libraries`

### DIFF
--- a/templates/example/flake.nix
+++ b/templates/example/flake.nix
@@ -292,6 +292,7 @@
 
       # lists of the functions you would have passed to
       # python.withPackages or lua.withPackages
+      # do not forget to set `hosts.python3.enable` in package settings
 
       # get the path to this python environment
       # in your lua config via

--- a/templates/flakeless/default.nix
+++ b/templates/flakeless/default.nix
@@ -71,6 +71,7 @@
     # in your lua config via
     # vim.g.python3_host_prog
     # or run from nvim terminal via :!<packagename>-python3
+    # do not forget to set `hosts.python3.enable` in package settings
     python3.libraries = {
       test = (_:[]);
     };

--- a/templates/fresh/flake.nix
+++ b/templates/fresh/flake.nix
@@ -138,6 +138,7 @@
 
       # lists of the functions you would have passed to
       # python.withPackages or lua.withPackages
+      # do not forget to set `hosts.python3.enable` in package settings
 
       # get the path to this python environment
       # in your lua config via

--- a/templates/kickstart-nvim/flake.nix
+++ b/templates/kickstart-nvim/flake.nix
@@ -205,6 +205,7 @@
 
       # lists of the functions you would have passed to
       # python.withPackages or lua.withPackages
+      # do not forget to set `hosts.python3.enable` in package settings
 
       # get the path to this python environment
       # in your lua config via

--- a/templates/nixExpressionFlakeOutputs/default.nix
+++ b/templates/nixExpressionFlakeOutputs/default.nix
@@ -86,6 +86,7 @@
 
     # lists of the functions you would have passed to
     # python.withPackages or lua.withPackages
+    # do not forget to set `hosts.python3.enable` in package settings
 
     # get the path to this python environment
     # in your lua config via


### PR DESCRIPTION
Character limit is only 72 characters, so the message is kind of wanky
