### PR TITLE
fix(templates): converting templates to new lsp scheme for 0.11

### DIFF
--- a/nixCatsHelp/nixCats_luaUtils.txt
+++ b/nixCatsHelp/nixCats_luaUtils.txt
@@ -201,16 +201,11 @@ only stuff pertaining to downloading and building should be added to paq.
     -- packadd with the same name both on and off Nix.
     { 'L3MON4D3/LuaSnip', opt = true, as = "luasnip", },
 
-    { 'saadparwaiz1/cmp_luasnip', opt = true, },
-    { 'hrsh7th/cmp-nvim-lsp', opt = true, },
-    { 'hrsh7th/cmp-nvim-lua', opt = true, },
-    { 'hrsh7th/cmp-nvim-lsp-signature-help', opt = true, },
-    { 'hrsh7th/cmp-path', opt = true, },
-    { 'rafamadriz/friendly-snippets', opt = true, },
-    { 'hrsh7th/cmp-buffer', opt = true, },
+    { 'L3MON4D3/LuaSnip', opt = true, as = "luasnip", },
     { 'hrsh7th/cmp-cmdline', opt = true, },
-    { 'dmitmel/cmp-cmdline-history', opt = true, },
-    { 'hrsh7th/nvim-cmp', opt = true, },
+    { 'Saghen/blink.cmp', opt = true, },
+    { 'Saghen/blink.compat', opt = true, },
+    { 'xzbdmw/colorful-menu.nvim', opt = true, },
 
     -- lint and format
     { 'mfussenegger/nvim-lint', opt = true, },

--- a/nixCatsHelp/nix_LSPS.txt
+++ b/nixCatsHelp/nix_LSPS.txt
@@ -5,13 +5,14 @@ MASON AND LSPCONFIG                                             *nixCats.LSPs*
 This is a method you may use to make sure mason only tries to download stuff
 when you did not install Neovim via nixCats
 
+When not using nix you will of course be responsible for downloading mason
+using something else.
+
 It functions the same as what kickstart.nvim does for its mason setup.
 However, when loaded via Nix,
-it skips mason and passes them straight to nvim-lspconfig
+it skips mason and enables them with default configs provided by nvim-lspconfig.
 
-When installing via paq-nvim, install mason via paq-nvim. Then wherever you set up
-mason, do this.
-The stuff added to servers table is what is passed to lspconfig/mason
+The following assumes that you have nvim-lspconfig loaded as a startup plugin
 
 >lua
   local servers = {}
@@ -132,62 +133,7 @@ The stuff added to servers table is what is passed to lspconfig/mason
   -- servers.html = { filetypes = { 'html', 'twig', 'hbs'} }
 
 
-  -- If you were to comment out this autocommand
-  -- and instead pass the on attach function directly to
-  -- nvim-lspconfig, it would do the same thing.
-  vim.api.nvim_create_autocmd('LspAttach', {
-    group = vim.api.nvim_create_augroup('nixCats-lsp-attach', { clear = true }),
-    callback = function(event)
-      require('myLuaConf.LSPs.caps-on_attach').on_attach(vim.lsp.get_client_by_id(event.data.client_id), event.buf)
-    end
-  })
-  if require('nixCatsUtils').isNixCats then
-    for server_name, cfg in pairs(servers) do
-      require('lspconfig')[server_name].setup({
-        capabilities = require('myLuaConf.LSPs.caps-on_attach').get_capabilities(server_name),
-        -- this line is interchangeable with the above LspAttach autocommand
-        -- on_attach = require('myLuaConf.LSPs.caps-on_attach').on_attach,
-        settings = (cfg or {}).settings,
-        filetypes = (cfg or {}).filetypes,
-        cmd = (cfg or {}).cmd,
-        root_pattern = (cfg or {}).root_pattern,
-      })
-    end
-
-  else
-    require('mason').setup()
-    local mason_lspconfig = require 'mason-lspconfig'
-    mason_lspconfig.setup {
-      ensure_installed = vim.tbl_keys(servers),
-    }
-    mason_lspconfig.setup_handlers {
-      function(server_name)
-        require('lspconfig')[server_name].setup {
-          capabilities = require('myLuaConf.LSPs.caps-on_attach').get_capabilities(server_name),
-          -- this line is interchangeable with the above LspAttach autocommand
-          -- on_attach = require('myLuaConf.LSPs.caps-on_attach').on_attach,
-          settings = (servers[server_name] or {}).settings,
-          filetypes = (servers[server_name] or {}).filetypes,
-        }
-      end,
-    }
-  end
-<
----------------------------------------------------------------------------------
-                                                 *nixCats.LSPs.caps-on_attach*
-
-The above snippet mentions another file at the end.
-
-caps-on_attach.lua or 'myLuaConf.LSPs.caps-on_attach'
-
-It is simply a file containing the function we want to run on LSP attach, and a
-function to return our completion capabilities object.
-
-It looks like this:
-
->lua
-  local M = {}
-  function M.on_attach(_, bufnr)
+  local function on_attach(_, bufnr)
     -- we create a function that lets us more easily define mappings specific
     -- for LSP related items. It sets the mode, buffer and description for us each time.
 
@@ -227,21 +173,42 @@ It looks like this:
     end, { desc = 'Format current buffer with LSP' })
 
   end
+  vim.api.nvim_create_autocmd('LspAttach', {
+    group = vim.api.nvim_create_augroup('nixCats-lsp-attach', { clear = true }),
+    callback = function(event)
+      on_attach(vim.lsp.get_client_by_id(event.data.client_id), event.buf)
+    end
+  })
 
-  function M.get_capabilities(server_name)
-    -- you may wish to know which server you're using to set different capabilities
-    -- if server_name is omitted, it will be nil
-
-    -- nvim-cmp supports additional completion capabilities, so broadcast that to servers
-    -- if you make a package without it, make sure to check if it exists with nixCats!
+  -- if nixCats('nvim-cmp') then
     local capabilities = vim.lsp.protocol.make_client_capabilities()
     capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
-    capabilities.textDocument.completion.completionItem.snippetSupport = true
-    return capabilities
+    vim.lsp.config('*', { capabilities = capabilities })
+  -- end
+
+  -- Check if we used nix, only run mason if we did not
+  if require('nixCatsUtils').isNixCats then
+    for server_name, cfg in pairs(servers) do
+      -- This gets provided a default configuration by nvim-lspconfig
+      -- and then ours gets tbl_deep_extend'ed into it
+      vim.lsp.config(server_name, cfg)
+      vim.lsp.enable(server_name)
+    end
+
+  else
+    require('mason').setup()
+    local mason_lspconfig = require 'mason-lspconfig'
+    mason_lspconfig.setup {
+      ensure_installed = vim.tbl_keys(servers),
+    }
+    mason_lspconfig.setup_handlers {
+      function(server_name)
+        local server = servers[server_name] or {}
+        vim.lsp.config(server_name, server)
+        vim.lsp.enable(server_name)
+      end,
+    }
   end
-  return M
 <
-
-
 =================================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/nixCatsHelp/tags
+++ b/nixCatsHelp/tags
@@ -1,6 +1,5 @@
 nixCats	nixCats_plugin.txt	/*nixCats*
 nixCats.LSPs	nix_LSPS.txt	/*nixCats.LSPs*
-nixCats.LSPs.caps-on_attach	nix_LSPS.txt	/*nixCats.LSPs.caps-on_attach*
 nixCats.LSPs.mason	nix_LSPS.txt	/*nixCats.LSPs.mason*
 nixCats.flake	nixCats_format.txt	/*nixCats.flake*
 nixCats.flake.inputs	nixCats_format.txt	/*nixCats.flake.inputs*

--- a/templates/example/flake.nix
+++ b/templates/example/flake.nix
@@ -201,20 +201,12 @@
           lazydev-nvim
         ];
         general = {
-          cmp = with pkgs.vimPlugins; [
-            # cmp stuff
-            nvim-cmp
+          blink = with pkgs.vimPlugins; [
             luasnip
-            friendly-snippets
-            cmp_luasnip
-            cmp-buffer
-            cmp-path
-            cmp-nvim-lua
-            cmp-nvim-lsp
             cmp-cmdline
-            cmp-nvim-lsp-signature-help
-            cmp-cmdline-history
-            lspkind-nvim
+            blink-cmp
+            blink-compat
+            colorful-menu-nvim
           ];
           treesitter = with pkgs.vimPlugins; [
             nvim-treesitter-textobjects

--- a/templates/example/lua/myLuaConf/LSPs/init.lua
+++ b/templates/example/lua/myLuaConf/LSPs/init.lua
@@ -2,22 +2,34 @@ local catUtils = require('nixCatsUtils')
 if (catUtils.isNixCats and nixCats('lspDebugMode')) then
   vim.lsp.set_log_level("debug")
 end
--- this is how to use the lsp handler.
+require('lze').h.lsp.set_ft_fallback(function(name)
+  local lspcfg = nixCats.pawsible({ "allPlugins", "opt", "nvim-lspconfig" }) or nixCats.pawsible({ "allPlugins", "start", "nvim-lspconfig" })
+  if not lspcfg then
+    local matches = vim.api.nvim_get_runtime_file("pack/*/{start,opt}/nvim-lspconfig", false)
+    lspcfg = assert(matches[1], "nvim-lspconfig not found!")
+  end
+  local ok, cfg = pcall(dofile, lspcfg .. "/lsp/" .. name .. ".lua")
+  if not ok then
+    ok, cfg = pcall(dofile, lspcfg .. "/lua/lspconfig/configs/" .. name .. ".lua")
+  end
+  return (ok and cfg or {}).filetypes or {}
+end)
+-- file uses lzextras.lsp handler
 require('lze').load {
   {
     "nvim-lspconfig",
     for_cat = "general.core",
-    -- the on require handler will be needed here if you want to use the
-    -- fallback method of getting filetypes if you don't provide any
     on_require = { "lspconfig" },
     -- define a function to run over all type(plugin.lsp) == table
     -- when their filetype trigger loads them
     lsp = function(plugin)
-      -- in this case, just extend some default arguments with the ones provided in the lsp table
-      require('lspconfig')[plugin.name].setup(vim.tbl_extend("force",{
-        capabilities = require('myLuaConf.LSPs.caps-on_attach').get_capabilities(plugin.name),
-        on_attach = require('myLuaConf.LSPs.caps-on_attach').on_attach,
-      }, plugin.lsp or {}))
+      vim.lsp.config(plugin.name, plugin.lsp or {})
+      vim.lsp.enable(plugin.name)
+    end,
+    before = function(_)
+      vim.lsp.config('*', {
+        on_attach = require('myLuaConf.LSPs.on_attach'),
+      })
     end,
   },
   {
@@ -79,7 +91,9 @@ require('lze').load {
     "gopls",
     for_cat = "go",
     -- if you don't provide the filetypes it asks lspconfig for them
-    lsp = {},
+    lsp = {
+      filetypes = { "go", "gomod", "gowork", "gotmpl" },
+    },
   },
   {
     "rnix",

--- a/templates/example/lua/myLuaConf/LSPs/on_attach.lua
+++ b/templates/example/lua/myLuaConf/LSPs/on_attach.lua
@@ -1,5 +1,4 @@
-local M = {}
-function M.on_attach(_, bufnr)
+return function(_, bufnr)
   -- we create a function that lets us more easily define mappings specific
   -- for LSP related items. It sets the mode, buffer and description for us each time.
 
@@ -46,15 +45,3 @@ function M.on_attach(_, bufnr)
   end, { desc = 'Format current buffer with LSP' })
 
 end
-
-function M.get_capabilities(server_name)
-  -- nvim-cmp supports additional completion capabilities, so broadcast that to servers
-  -- if you make a package without it, make sure to check if it exists with nixCats!
-  local capabilities = vim.lsp.protocol.make_client_capabilities()
-  if nixCats('general.cmp') then
-    capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
-  end
-  capabilities.textDocument.completion.completionItem.snippetSupport = true
-  return capabilities
-end
-return M

--- a/templates/example/lua/myLuaConf/non_nix_download.lua
+++ b/templates/example/lua/myLuaConf/non_nix_download.lua
@@ -49,18 +49,11 @@ require('nixCatsUtils.catPacker').setup({
   { 'folke/lazydev.nvim', opt = true, },
 
   -- completion
-  { 'onsails/lspkind.nvim', opt = true, },
   { 'L3MON4D3/LuaSnip', opt = true, as = "luasnip", },
-  { 'saadparwaiz1/cmp_luasnip', opt = true, },
-  { 'hrsh7th/cmp-nvim-lsp', opt = true, },
-  { 'hrsh7th/cmp-nvim-lua', opt = true, },
-  { 'hrsh7th/cmp-nvim-lsp-signature-help', opt = true, },
-  { 'hrsh7th/cmp-path', opt = true, },
-  { 'rafamadriz/friendly-snippets', opt = true, },
-  { 'hrsh7th/cmp-buffer', opt = true, },
   { 'hrsh7th/cmp-cmdline', opt = true, },
-  { 'dmitmel/cmp-cmdline-history', opt = true, },
-  { 'hrsh7th/nvim-cmp', opt = true, },
+  { 'Saghen/blink.cmp', opt = true, },
+  { 'Saghen/blink.compat', opt = true, },
+  { 'xzbdmw/colorful-menu.nvim', opt = true, },
 
   -- lint and format
   { 'mfussenegger/nvim-lint', opt = true, },

--- a/templates/example/lua/myLuaConf/plugins/completion.lua
+++ b/templates/example/lua/myLuaConf/plugins/completion.lua
@@ -5,70 +5,21 @@ end
 
 return {
   {
-    "cmp-buffer",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
     "cmp-cmdline",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
+    for_cat = "general.blink",
+    on_plugin = { "blink.cmp" },
     load = load_w_after,
   },
   {
-    "cmp-cmdline-history",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
-    "cmp-nvim-lsp",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    dep_of = { "nvim-lspconfig" },
-    load = load_w_after,
-  },
-  {
-    "cmp-nvim-lsp-signature-help",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
-    "cmp-nvim-lua",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
-    "cmp-path",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
-    "cmp_luasnip",
-    for_cat = 'general.cmp',
-    on_plugin = { "nvim-cmp" },
-    load = load_w_after,
-  },
-  {
-    "friendly-snippets",
-    for_cat = 'general.cmp',
-    dep_of = { "nvim-cmp" },
-  },
-  {
-    "lspkind.nvim",
-    for_cat = 'general.cmp',
-    dep_of = { "nvim-cmp" },
-    load = load_w_after,
+    "blink.compat",
+    for_cat = "general.blink",
+    dep_of = { "cmp-cmdline" },
   },
   {
     "luasnip",
-    for_cat = 'general.cmp',
-    dep_of = { "nvim-cmp" },
-    after = function (plugin)
+    for_cat = "general.blink",
+    dep_of = { "blink.cmp" },
+    after = function (_)
       local luasnip = require 'luasnip'
       require('luasnip.loaders.from_vscode').lazy_load()
       luasnip.config.setup {}
@@ -83,128 +34,95 @@ return {
     end,
   },
   {
-    "nvim-cmp",
-    for_cat = 'general.cmp',
-    -- cmd = { "" },
-    event = { "DeferredUIEnter" },
-    on_require = { "cmp" },
-    -- ft = "",
-    -- keys = "",
-    -- colorscheme = "",
-    after = function (plugin)
-      -- [[ Configure nvim-cmp ]]
-      -- See `:help cmp`
-      local cmp = require 'cmp'
-      local luasnip = require 'luasnip'
-      local lspkind = require 'lspkind'
-
-      cmp.setup {
-        formatting = {
-          format = lspkind.cmp_format {
-            mode = 'text',
-            with_text = true,
-            maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
-            ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
-
+    "colorful-menu.nvim",
+    for_cat = "general.blink",
+    on_plugin = { "blink.cmp" },
+  },
+  {
+    "blink.cmp",
+    for_cat = "general.blink",
+    event = "DeferredUIEnter",
+    after = function (_)
+      require("blink.cmp").setup({
+        -- 'default' (recommended) for mappings similar to built-in completions (C-y to accept)
+        -- See :h blink-cmp-config-keymap for configuring keymaps
+        keymap =  {
+          preset = 'default',
+        },
+        cmdline = {
+          enabled = true,
+          completion = {
             menu = {
-              buffer = '[BUF]',
-              nvim_lsp = '[LSP]',
-              nvim_lsp_signature_help = '[LSP]',
-              nvim_lsp_document_symbol = '[LSP]',
-              nvim_lua = '[API]',
-              path = '[PATH]',
-              luasnip = '[SNIP]',
+              auto_show = true,
             },
           },
-        },
-        snippet = {
-          expand = function(args)
-            luasnip.lsp_expand(args.body)
+          sources = function()
+            local type = vim.fn.getcmdtype()
+            -- Search forward and backward
+            if type == '/' or type == '?' then return { 'buffer' } end
+            -- Commands
+            if type == ':' or type == '@' then return { 'cmdline', 'cmp_cmdline' } end
+            return {}
           end,
         },
-        mapping = cmp.mapping.preset.insert {
-          ['<C-p>'] = cmp.mapping.scroll_docs(-4),
-          ['<C-n>'] = cmp.mapping.scroll_docs(4),
-          ['<C-Space>'] = cmp.mapping.complete {},
-          ['<CR>'] = cmp.mapping.confirm {
-            behavior = cmp.ConfirmBehavior.Replace,
-            select = true,
+        fuzzy = {
+          sorts = {
+            'exact',
+            -- defaults
+            'score',
+            'sort_text',
           },
-          ['<Tab>'] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_next_item()
-            elseif luasnip.expand_or_locally_jumpable() then
-              luasnip.expand_or_jump()
-            else
-              fallback()
-            end
-          end, { 'i', 's' }),
-          ['<S-Tab>'] = cmp.mapping(function(fallback)
-            if cmp.visible() then
-              cmp.select_prev_item()
-            elseif luasnip.locally_jumpable(-1) then
-              luasnip.jump(-1)
-            else
-              fallback()
-            end
-          end, { 'i', 's' }),
         },
-
-        sources = cmp.config.sources {
-          -- The insertion order influences the priority of the sources
-          { name = 'nvim_lsp'--[[ , keyword_length = 3 ]] },
-          { name = 'nvim_lsp_signature_help'--[[ , keyword_length = 3  ]]},
-          { name = 'path' },
-          { name = 'luasnip' },
-          { name = 'buffer' },
+        signature = {
+          enabled = true,
+          window = {
+            show_documentation = true,
+          },
         },
-        enabled = function()
-          return vim.bo[0].buftype ~= 'prompt'
-        end,
-        experimental = {
-          native_menu = false,
-          ghost_text = false,
-        },
-      }
-
-      cmp.setup.filetype('lua', {
-        sources = cmp.config.sources {
-          { name = 'nvim_lua' },
-          { name = 'nvim_lsp'--[[ , keyword_length = 3  ]]},
-          { name = 'nvim_lsp_signature_help'--[[ , keyword_length = 3  ]]},
-          { name = 'path' },
-          { name = 'luasnip' },
-          { name = 'buffer' },
-        },{
-          {
-            name = 'cmdline',
-            option = {
-              ignore_cmds = { 'Man', '!' },
+        completion = {
+          menu = {
+            draw = {
+              treesitter = { 'lsp' },
+              components = {
+                label = {
+                  text = function(ctx)
+                    return require("colorful-menu").blink_components_text(ctx)
+                  end,
+                  highlight = function(ctx)
+                    return require("colorful-menu").blink_components_highlight(ctx)
+                  end,
+                },
+              },
             },
           },
+          documentation = {
+            auto_show = true,
+          },
         },
-      })
-
-      -- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
-      cmp.setup.cmdline({ '/', '?' }, {
-        mapping = cmp.mapping.preset.cmdline(),
+        snippets = {
+          preset = 'luasnip',
+        },
         sources = {
-          { name = 'nvim_lsp_document_symbol'--[[ , keyword_length = 3  ]]},
-          { name = 'buffer' },
-          { name = 'cmdline_history' },
-        },
-        view = {
-          entries = { name = 'wildmenu', separator = '|' },
-        },
-      })
-
-      -- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
-      cmp.setup.cmdline(':', {
-        mapping = cmp.mapping.preset.cmdline(),
-        sources = cmp.config.sources {
-          { name = 'cmdline' },
-          -- { name = 'cmdline_history' },
-          { name = 'path' },
+          default = { 'lsp', 'path', 'snippets', 'buffer', 'omni' },
+          providers = {
+            path = {
+              score_offset = 50,
+            },
+            lsp = {
+              score_offset = 40,
+            },
+            snippets = {
+              score_offset = 40,
+            },
+            cmp_cmdline = {
+              name = 'cmp_cmdline',
+              module = 'blink.compat.source',
+              score_offset = -100,
+              opts = {
+                cmp_name = 'cmdline',
+              },
+            },
+          },
         },
       })
     end,

--- a/templates/home-manager/init.lua
+++ b/templates/home-manager/init.lua
@@ -658,25 +658,16 @@ local function lsp_on_attach(_, bufnr)
 
 end
 
-local function get_lsp_capabilities(server_name)
-  -- nvim-cmp supports additional completion capabilities, so broadcast that to servers
-  -- if you make a package without it, make sure to check if it exists with nixCats!
-  local capabilities = {}
-  if nixCats('general') then
-    capabilities = require('blink.cmp').get_lsp_capabilities(capabilities, true)
-  else
-    capabilities = vim.tbl_deep_extend('force', vim.lsp.protocol.make_client_capabilities(), capabilities)
-  end
-  return capabilities
-end
-
 -- NOTE: Register a handler from lzextras. This one makes it so that
 -- you can set up lsps within lze specs,
--- and trigger lspconfig setup only on the correct filetypes
+-- and trigger vim.lsp.enable and the rtp config collection only on the correct filetypes
 -- it adds the lsp field used below
 -- (and must be registered before any load calls that use it!)
 require('lze').register_handlers(require('lzextras').lsp)
-
+-- also replace the fallback filetype list retrieval function with a slightly faster one
+require('lze').h.lsp.set_ft_fallback(function(name)
+  return dofile(nixCats.pawsible({ "allPlugins", "opt", "nvim-lspconfig" }) .. "/lsp/" .. name .. ".lua").filetypes or {}
+end)
 require('lze').load {
   {
     "nvim-lspconfig",
@@ -687,13 +678,13 @@ require('lze').load {
     -- define a function to run over all type(plugin.lsp) == table
     -- when their filetype trigger loads them
     lsp = function(plugin)
-      -- in this case, just extend some default arguments with the ones provided in the lsp table
-      require('lspconfig')[plugin.name].setup(vim.tbl_extend("force",{
-        -- provide our capabilities and our on_attach function by default
-        capabilities = get_lsp_capabilities(plugin.name),
+      vim.lsp.config(plugin.name, plugin.lsp or {})
+      vim.lsp.enable(plugin.name)
+    end,
+    before = function(_)
+      vim.lsp.config('*', {
         on_attach = lsp_on_attach,
-        -- and add the config from each spec to the defaults here and call lspconfig with it
-      }, plugin.lsp or {}))
+      })
     end,
   },
   {
@@ -726,8 +717,10 @@ require('lze').load {
   {
     "gopls",
     enabled = nixCats("go") or false,
-    -- if you don't provide the filetypes it asks lspconfig for them
-    lsp = {},
+    -- if you don't provide the filetypes it asks lspconfig for them using the function we set above
+    lsp = {
+      -- filetypes = { "go", "gomod", "gowork", "gotmpl" },
+    },
   },
   {
     "nixd",

--- a/templates/kickstart-nvim/init.lua
+++ b/templates/kickstart-nvim/init.lua
@@ -107,7 +107,7 @@ vim.g.maplocalleader = ' '
 -- Set to true if you have a Nerd Font installed and selected in the terminal
 -- NOTE: nixCats: we asked nix if we have it instead of setting it here.
 -- because nix is more likely to know if we have a nerd font or not.
-vim.g.have_nerd_font = nixCats("have_nerd_font")
+vim.g.have_nerd_font = nixCats 'have_nerd_font'
 
 -- [[ Setting options ]]
 -- See `:help vim.opt`
@@ -220,13 +220,12 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   end,
 })
 
-
 -- NOTE: nixCats: You might want to move the lazy-lock.json file
 local function getlockfilepath()
-  if require('nixCatsUtils').isNixCats and type(nixCats.settings.unwrappedCfgPath) == "string" then
-    return nixCats.settings.unwrappedCfgPath .. "/lazy-lock.json"
+  if require('nixCatsUtils').isNixCats and type(nixCats.settings.unwrappedCfgPath) == 'string' then
+    return nixCats.settings.unwrappedCfgPath .. '/lazy-lock.json'
   else
-    return vim.fn.stdpath("config") .. "/lazy-lock.json"
+    return vim.fn.stdpath 'config' .. '/lazy-lock.json'
   end
 end
 local lazyOptions = {
@@ -265,8 +264,7 @@ local lazyOptions = {
 -- NOTE: Here is where you install your plugins.
 -- NOTE: nixCats: this the lazy wrapper. Use it like require('lazy').setup() but with an extra
 -- argument, the path to lazy.nvim as downloaded by nix, or nil, before the normal arguments.
-require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "lazy.nvim" }),
-{
+require('nixCatsUtils.lazyCat').setup(nixCats.pawsible { 'allPlugins', 'start', 'lazy.nvim' }, {
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
   'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
 
@@ -282,7 +280,7 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
   -- "gc" to comment visual regions/lines
   -- NOTE: nixCats: nix downloads it with a different file name.
   -- tell lazy about that.
-  { 'numToStr/Comment.nvim', name = "comment.nvim", opts = {} },
+  { 'numToStr/Comment.nvim', name = 'comment.nvim', opts = {} },
 
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`. This is equivalent to the following Lua:
@@ -366,7 +364,7 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
         -- This is only run then, not every time Neovim starts up.
         -- NOTE: nixCats: use lazyAdd to only run build steps if nix wasnt involved.
         -- because nix already did this.
-        build = require('nixCatsUtils').lazyAdd('make'),
+        build = require('nixCatsUtils').lazyAdd 'make',
 
         -- `cond` is a condition used to determine whether this plugin should be
         -- installed and loaded.
@@ -492,13 +490,15 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
 
       -- `neodev` configures Lua LSP for your Neovim config, runtime and plugins
       -- used for completion, annotations and signatures of Neovim apis
-      { 'folke/lazydev.nvim', ft = "lua",
+      {
+        'folke/lazydev.nvim',
+        ft = 'lua',
         opts = {
           library = {
             -- adds type hints for nixCats global
-            { path = (nixCats.nixCatsPath or "") .. '/lua', words = { "nixCats" } },
+            { path = (nixCats.nixCatsPath or '') .. '/lua', words = { 'nixCats' } },
           },
-        }
+        },
       },
       -- kickstart.nvim was still on neodev. lazydev is the new version of neodev
     },
@@ -632,6 +632,7 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
       --  So, we create new capabilities with nvim cmp, and then broadcast that to the servers.
       local capabilities = vim.lsp.protocol.make_client_capabilities()
       capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
+      vim.lsp.config('*', { capabilities = capabilities })
 
       -- Enable the following language servers
       --  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
@@ -644,18 +645,18 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
       --        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
       -- NOTE: nixCats: there is help in nixCats for lsps at `:h nixCats.LSPs` and also `:h nixCats.luaUtils`
       local servers = {}
-        -- servers.clangd = {},
-        -- servers.gopls = {},
-        -- servers.pyright = {},
-        -- servers.rust_analyzer = {},
-        -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
-        --
-        -- Some languages (like typescript) have entire language plugins that can be useful:
-        --    https://github.com/pmizio/typescript-tools.nvim
-        --
-        -- But for many setups, the LSP (`tsserver`) will work just fine
-        -- servers.tsserver = {},
-        --
+      -- servers.clangd = {},
+      -- servers.gopls = {},
+      -- servers.pyright = {},
+      -- servers.rust_analyzer = {},
+      -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
+      --
+      -- Some languages (like typescript) have entire language plugins that can be useful:
+      --    https://github.com/pmizio/typescript-tools.nvim
+      --
+      -- But for many setups, the LSP (`tsserver`) will work just fine
+      -- servers.tsserver = {},
+      --
 
       -- NOTE: nixCats: nixd is not available on mason.
       -- Feel free to check the nixd docs for more configuration options:
@@ -677,7 +678,7 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
             },
             -- You can toggle below to ignore Lua_LS's noisy `missing-fields` warnings
             diagnostics = {
-              globals = { "nixCats" },
+              globals = { 'nixCats' },
               disable = { 'missing-fields' },
             },
           },
@@ -688,17 +689,13 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
       -- You could MAKE it work, using lspsAndRuntimeDeps and sharedLibraries in nixCats
       -- but don't... its not worth it. Just add the lsp to lspsAndRuntimeDeps.
       if require('nixCatsUtils').isNixCats then
-        for server_name,_ in pairs(servers) do
-          require('lspconfig')[server_name].setup({
-            capabilities = capabilities,
-            settings = (servers[server_name] or {}).settings,
-            filetypes = (servers[server_name] or {}).filetypes,
-            cmd = (servers[server_name] or {}).cmd,
-            root_pattern = (servers[server_name] or {}).root_pattern,
-          })
+        -- set up the servers to be loaded on the appropriate filetypes!
+        for server_name, cfg in pairs(servers) do
+          vim.lsp.config(server_name, cfg)
+          vim.lsp.enable(server_name)
         end
       else
-        -- NOTE: nixCats: and if no nix, do it the normal way
+        -- NOTE: nixCats: and if no nix, use mason
 
         -- Ensure the servers and tools above are installed
         --  To check the current status of installed tools and/or manually install
@@ -719,12 +716,8 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
         require('mason-lspconfig').setup {
           handlers = {
             function(server_name)
-              local server = servers[server_name] or {}
-              -- This handles overriding only values explicitly passed
-              -- by the server configuration above. Useful when disabling
-              -- certain features of an LSP (for example, turning off formatting for tsserver)
-              server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-              require('lspconfig')[server_name].setup(server)
+              vim.lsp.config(server_name, servers[server_name] or {})
+              vim.lsp.enable(server_name)
             end,
           },
         }
@@ -943,11 +936,11 @@ require('nixCatsUtils.lazyCat').setup(nixCats.pawsible({"allPlugins", "start", "
   },
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
-    build = require('nixCatsUtils').lazyAdd(':TSUpdate'),
+    build = require('nixCatsUtils').lazyAdd ':TSUpdate',
     opts = {
       -- NOTE: nixCats: use lazyAdd to only set these 2 options if nix wasnt involved.
       -- because nix already ensured they were installed.
-      ensure_installed = require('nixCatsUtils').lazyAdd({ 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' }),
+      ensure_installed = require('nixCatsUtils').lazyAdd { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
       auto_install = require('nixCatsUtils').lazyAdd(true, false),
 
       highlight = {

--- a/templates/simple/default.nix
+++ b/templates/simple/default.nix
@@ -28,7 +28,9 @@
         snacks-nvim
         onedark-nvim
         vim-sleuth
-        mini-nvim
+        mini-ai
+        mini-icons
+        mini-pairs
         nvim-lspconfig
         vim-startuptime
         blink-cmp
@@ -67,8 +69,10 @@
         # IMPORTANT:
         # your aliases may not conflict with other packages.
         # aliases = [ "vim" ];
-        hosts.python3.enable = true;
-        hosts.node.enable = true;
+        hosts.python3.enable = false;
+        hosts.node.enable = false;
+        hosts.ruby.enable = false;
+        hosts.perl.enable = false;
       };
       # and a set of categories that you want
       # All categories you wish to include must be marked true

--- a/templates/simple/ftplugin/lua.lua
+++ b/templates/simple/ftplugin/lua.lua
@@ -5,7 +5,7 @@ end
 -- we are also using this as an opportunity to show you how to lazy load plugins!
 -- This plugin was added to the optionalPlugins section of the main nix file of this template.
 -- Thus, it is not loaded and must be packadded.
--- NOTE: Use `:nixCats pawsible` to see the names of all plugins downloaded via Nix for packad.
+-- NOTE: Use `:nixCats pawsible` to see the names of all plugins downloaded via Nix for packadd.
 vim.cmd.packadd('lazydev.nvim')
 require('lazydev').setup({
   library = {

--- a/templates/simple/plugin/completion.lua
+++ b/templates/simple/plugin/completion.lua
@@ -12,5 +12,16 @@ require("blink.cmp").setup({
   signature = { enabled = true, },
   sources = {
     default = { 'lsp', 'path', 'snippets', 'buffer' },
+    providers = {
+      path = {
+        score_offset = 50,
+      },
+      lsp = {
+        score_offset = 40,
+      },
+      snippets = {
+        score_offset = 40,
+      },
+    },
   },
 })

--- a/templates/simple/plugin/general_ui.lua
+++ b/templates/simple/plugin/general_ui.lua
@@ -11,24 +11,6 @@ vim.g.startuptime_exe_path = nixCats.packageBinPath
 require('mini.pairs').setup()
 require('mini.icons').setup()
 require('mini.ai').setup()
-require('mini.files').setup({
-  mappings = {
-    close       = 'q',
-    go_in       = 'l',
-    go_in_plus  = 'L',
-    go_out      = 'h',
-    go_out_plus = 'H',
-    mark_goto   = "'",
-    mark_set    = 'm',
-    reset       = '<BS>',
-    reveal_cwd  = '@',
-    show_help   = 'g?',
-    synchronize = '=',
-    trim_left   = '<',
-    trim_right  = '>',
-  },
-})
-vim.keymap.set("n", "-", function() MiniFiles.open() end, { desc = 'mini.files explorer' })
 
 require('lualine').setup({
   options = {

--- a/templates/simple/plugin/lsp.lua
+++ b/templates/simple/plugin/lsp.lua
@@ -66,51 +66,48 @@ servers.nixd = {
   }
 }
 
-local lspconfig = require('lspconfig')
-lspconfig.util.default_config = vim.tbl_extend(
-  "force",
-  lspconfig.util.default_config,
-  {
-    capabilities = require('blink.cmp').get_lsp_capabilities({}, true),
-    on_attach = function(_, bufnr)
-      -- we create a function that lets us more easily define mappings specific
-      -- for LSP related items. It sets the mode, buffer and description for us each time.
-      local nmap = function(keys, func, desc)
-        if desc then
-          desc = 'LSP: ' .. desc
-        end
-        vim.keymap.set('n', keys, func, { buffer = bufnr, desc = desc })
+vim.lsp.config('*', {
+  -- capabilities = capabilities,
+  on_attach = function(_, bufnr)
+    -- we create a function that lets us more easily define mappings specific
+    -- for LSP related items. It sets the mode, buffer and description for us each time.
+    local nmap = function(keys, func, desc)
+      if desc then
+        desc = 'LSP: ' .. desc
       end
+      vim.keymap.set('n', keys, func, { buffer = bufnr, desc = desc })
+    end
 
-      nmap('<leader>rn', vim.lsp.buf.rename, '[R]e[n]ame')
-      nmap('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction')
-      nmap('gd', vim.lsp.buf.definition, '[G]oto [D]efinition')
-      nmap('<leader>D', vim.lsp.buf.type_definition, 'Type [D]efinition')
-      nmap('gr', function() Snacks.picker.lsp_references() end, '[G]oto [R]eferences')
-      nmap('gI', function() Snacks.picker.lsp_implementations() end, '[G]oto [I]mplementation')
-      nmap('<leader>ds', function() Snacks.picker.lsp_symbols() end, '[D]ocument [S]ymbols')
-      nmap('<leader>ws', function() Snacks.picker.lsp_workspace_symbols() end, '[W]orkspace [S]ymbols')
+    nmap('<leader>rn', vim.lsp.buf.rename, '[R]e[n]ame')
+    nmap('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction')
+    nmap('gd', vim.lsp.buf.definition, '[G]oto [D]efinition')
+    nmap('<leader>D', vim.lsp.buf.type_definition, 'Type [D]efinition')
+    nmap('gr', function() Snacks.picker.lsp_references() end, '[G]oto [R]eferences')
+    nmap('gI', function() Snacks.picker.lsp_implementations() end, '[G]oto [I]mplementation')
+    nmap('<leader>ds', function() Snacks.picker.lsp_symbols() end, '[D]ocument [S]ymbols')
+    nmap('<leader>ws', function() Snacks.picker.lsp_workspace_symbols() end, '[W]orkspace [S]ymbols')
 
-      -- See `:help K` for why this keymap
-      nmap('K', vim.lsp.buf.hover, 'Hover Documentation')
-      nmap('<C-k>', vim.lsp.buf.signature_help, 'Signature Documentation')
+    -- See `:help K` for why this keymap
+    nmap('K', vim.lsp.buf.hover, 'Hover Documentation')
+    nmap('<C-k>', vim.lsp.buf.signature_help, 'Signature Documentation')
 
-      -- Lesser used LSP functionality
-      nmap('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
-      nmap('<leader>wa', vim.lsp.buf.add_workspace_folder, '[W]orkspace [A]dd Folder')
-      nmap('<leader>wr', vim.lsp.buf.remove_workspace_folder, '[W]orkspace [R]emove Folder')
-      nmap('<leader>wl', function()
-        print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-      end, '[W]orkspace [L]ist Folders')
+    -- Lesser used LSP functionality
+    nmap('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')
+    nmap('<leader>wa', vim.lsp.buf.add_workspace_folder, '[W]orkspace [A]dd Folder')
+    nmap('<leader>wr', vim.lsp.buf.remove_workspace_folder, '[W]orkspace [R]emove Folder')
+    nmap('<leader>wl', function()
+      print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+    end, '[W]orkspace [L]ist Folders')
 
-      -- Create a command `:Format` local to the LSP buffer
-      vim.api.nvim_buf_create_user_command(bufnr, 'Format', function(_)
-        vim.lsp.buf.format()
-      end, { desc = 'Format current buffer with LSP' })
-    end,
-  }
-)
+    -- Create a command `:Format` local to the LSP buffer
+    vim.api.nvim_buf_create_user_command(bufnr, 'Format', function(_)
+      vim.lsp.buf.format()
+    end, { desc = 'Format current buffer with LSP' })
+  end,
+})
+
 -- set up the servers to be loaded on the appropriate filetypes!
 for server_name, cfg in pairs(servers) do
-  lspconfig[server_name].setup(cfg or {})
+  vim.lsp.config(server_name, cfg)
+  vim.lsp.enable(server_name)
 end

--- a/templates/simple/plugin/snacks.lua
+++ b/templates/simple/plugin/snacks.lua
@@ -5,6 +5,7 @@ require("snacks").setup({
   picker = {},
   bigfile = {},
   image = {},
+  explorer = { replace_netrw = true, },
   lazygit = {},
   terminal = {},
   rename = {},
@@ -17,6 +18,7 @@ vim.keymap.set("n", "<c-\\>", function() Snacks.terminal.open() end, { desc = 'S
 vim.keymap.set("n", "<leader>_", function() Snacks.lazygit.open() end, { desc = 'Snacks LazyGit' })
 vim.keymap.set('n', "<leader>sf", function() Snacks.picker.smart() end, { desc = "Smart Find Files" })
 vim.keymap.set('n', "<leader><leader>s", function() Snacks.picker.buffers() end, { desc = "Search Buffers" })
+vim.keymap.set("n", "-", function() Snacks.explorer.open() end, { desc = 'Snacks file explorer' })
 -- find
 vim.keymap.set('n', "<leader>ff", function() Snacks.picker.files() end, { desc = "Find Files" })
 vim.keymap.set('n', "<leader>fg", function() Snacks.picker.git_files() end, { desc = "Find Git Files" })


### PR DESCRIPTION
Pending https://nixpk.gs/pr-tracker.html?pr=398626

This change is to templates and help only.

If you find your LSPs do not start or an error is thrown when using the home manager template's example configuration, either your nixpkgs channel provided to your neovim is too old and doesnt have nvim-lspconfig 2.0.0 or nvim 0.11, or you pulled the template before it has been updated to use the new lsp configuration scheme.

You can pass a new nixpkgs to use via the [nixpkgs_version](https://nixcats.org/nixCats_hm_options.html#defaultpackagename.nixpkgs_version) module option

Neovim recently updated the [way it does its lsps](https://neovim.io/doc/user/lsp.html#_lua-module:-vim.lsp).

---

If you cannot update your nixpkgs input for other reasons, you should ensure you are using nvim 0.11+ still, (latest stable nixpkgs release, or set [neovim-unwrapped setting in packageDefinitions](https://nixcats.org/nixCats_format.html#nixCats.flake.outputs.settings)) and then pull the newest version of `nvim-lspconfig`

```nix
  inputs = {
    # ...
    "plugins-nvim-lspconfig" = {
      url = "github:neovim/nvim-lspconfig";
      flake = false;
    };
    # ...
  };
```

If your dependencyOverlays list or addOverlays option contains a call to [the standard plugin overlay](https://nixcats.org/nixCats_utils.html#function-library-nixCats.utils.standardPluginOverlay), you may then replace `pkgs.vimPlugins.nvim-lspconfig` with `pkgs.neovimPlugins.nvim-lspconfig`

If it doesn't, you can replace it with `(mkPlugin "nvim-lspconfig" inputs.plugins-nvim-lspconfig)` instead. (Where `mkPlugin` is provided by the arguments to your [categoryDefinitions](https://nixcats.org/nixCats_format.html#nixCats.flake.outputs.categories))