### PR TITLE
Remove parenthesis around %F for nvim.desktop

### DIFF
--- a/builder/wrapper.nix
+++ b/builder/wrapper.nix
@@ -63,7 +63,7 @@ in {
       "--replace-fail" "Name=Neovim" "Name=${nixCats_packageName}"
       "--replace-fail" "TryExec=nvim" "TryExec=${placeholder "out"}/bin/${nixCats_packageName}"
       "--replace-fail" "Icon=nvim" "Icon=${neovim-unwrapped}/share/icons/hicolor/128x128/apps/nvim.png" ]}
-    ${gnused}/bin/sed -i ${lib.escapeShellArgs [ "/^Exec=nvim/c\\Exec=${placeholder "out"}/bin/${nixCats_packageName} \"%F\"" "${placeholder "out"}/share/applications/${nixCats_packageName}.desktop" ]}
+    ${gnused}/bin/sed -i ${lib.escapeShellArgs [ "/^Exec=nvim/c\\Exec=${placeholder "out"}/bin/${nixCats_packageName} %F" "${placeholder "out"}/share/applications/${nixCats_packageName}.desktop" ]}
     ''
   + ''
     ${lib.concatMapStringsSep "\n" (alias: "ln -s ${lib.escapeShellArgs [ "${placeholder "out"}/bin/${nixCats_packageName}" "${placeholder "out"}/bin/${alias}" ]}") customAliases}


### PR DESCRIPTION
This parenthesis can mess the xdg-mime a little bit because it incorrectly reads the file name(it appends redundant apostrophe at the end of the file name, which prevents the file from opening(it creates a new one)).


Before:
![image](https://github.com/user-attachments/assets/b298cb25-1acb-433d-83f1-59146fd07e19)

After:
![image](https://github.com/user-attachments/assets/be05485f-ca50-44d2-8153-f91842084c60)


