### PR TITLE
docs(template): wrong cat in example (nvim-lspconfig)

### DIFF
--- a/templates/example/lua/myLuaConf/LSPs/init.lua
+++ b/templates/example/lua/myLuaConf/LSPs/init.lua
@@ -23,7 +23,7 @@ end)
 require('lze').load {
   {
     "nvim-lspconfig",
-    for_cat = "general.core",
+    for_cat = "general.always",
     on_require = { "lspconfig" },
     -- NOTE: define a function for lsp,
     -- and it will run for all specs with type(plugin.lsp) == table


### PR DESCRIPTION
specified as nonexistent cat: `general.core`; instead of `general.always`