### PR TITLE
Replace runCommandNoCC with runCommand

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -174,7 +174,7 @@
         nixCats_packageName = name;
         inherit nixCats_config_location wrappedCfgPath;
       };
-    in pkgs.runCommandNoCC "nixCats-plugin-${name}" {
+    in pkgs.runCommand "nixCats-plugin-${name}" {
       src = pkgs.replaceVars ./nixCats.lua {
         nixCatsPawsible = utils.n2l.toLua allPluginDeps;
         nixCatsExtra = utils.n2l.toLua extraTableLua;

--- a/tests/nvim/default.nix
+++ b/tests/nvim/default.nix
@@ -28,7 +28,7 @@
         pkgs.neovimPlugins.hlargs
       ];
       autoconf = [
-        ((pkgs.runCommandNoCC "autoconftest" {} ''mkdir -p $out'').overrideAttrs (prev: {
+        ((pkgs.runCommand "autoconftest" {} ''mkdir -p $out'').overrideAttrs (prev: {
           passthru = prev.passthru or {} // {
             initLua = ''
               vim.g.autoconf_test_nixCats = true
@@ -37,7 +37,7 @@
         }))
       ];
       autodeps = [
-        ((pkgs.runCommandNoCC "autodepstest" {} ''mkdir -p $out'').overrideAttrs (prev: {
+        ((pkgs.runCommand "autodepstest" {} ''mkdir -p $out'').overrideAttrs (prev: {
           runtimeDeps = prev.runtimeDeps or [] ++ [
             (pkgs.writeShellScriptBin "autodeps_test_nixCats" ''
               echo "HELLO WORLD I HAVE BEEN AUTOINCLUDED"


### PR DESCRIPTION
`runCommandNoCC` was recently replaced by `runCommand` in nixpkgs. This PR replaces the three occurences of `runCommandNoCC` with `runCommand`.