### PR TITLE
chore: replace deprecated uses of pkgs.system

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -14,7 +14,7 @@
       && (isPath luaPath || (isString luaPath && hasContext luaPath) || luaPath.outPath or null != null)) -> (import ./errors.nix).main;
   let
     system = let
-      val = args.system or args.pkgs.system or args.nixpkgs.system or builtins.system or (import ./errors.nix).main;
+      val = args.system or args.pkgs.stdenv.hostPlatform.system or args.nixpkgs.stdenv.hostPlatform.system or builtins.system or (import ./errors.nix).main;
     in if builtins.isString val then val else (import ./errors.nix).main;
     extra_pkg_config = if ! (builtins.isAttrs args.extra_pkg_config or {})
       then (import ./errors.nix).main
@@ -27,7 +27,7 @@
       overlays = if isList (args.dependencyOverlays or null)
         then args.dependencyOverlays
         else [];
-    in if (args.pkgs or null) != null && extra_pkg_config == {} && extra_pkg_params == {} && (args.pkgs.system or null) == system
+    in if (args.pkgs or null) != null && extra_pkg_config == {} && extra_pkg_params == {} && (args.pkgs.stdenv.hostPlatform.system or null) == system
       then if overlays == [] then args.pkgs else args.pkgs.appendOverlays overlays
       else import (args.pkgs.path or args.nixpkgs.path or args.nixpkgs.outPath or args.nixpkgs) ({
           inherit system;
@@ -323,7 +323,7 @@ in luaPath: pkgsParams: categoryDefinitions: packageDefinitions: name: let
     or (if builtins ? system then <nixpkgs> else (import ./errors.nix).main);
   newlib = pkgsParams.pkgs.lib or pkgsParams.nixpkgs.lib or (import "${nixpkgspath}/lib");
   mkOverride = nclib.makeOverridable newlib.overrideDerivation;
-  system = pkgsParams.system or pkgsParams.pkgs.system or pkgsParams.nixpkgs.system or builtins.system or (import ./errors.nix).main;
+  system = pkgsParams.system or pkgsParams.pkgs.stdenv.hostPlatform.system or pkgsParams.nixpkgs.stdenv.hostPlatform.system or builtins.system or (import ./errors.nix).main;
 in
 mkOverride main_builder {
   inherit system luaPath categoryDefinitions packageDefinitions name;

--- a/templates/LazyVim/flake.nix
+++ b/templates/LazyVim/flake.nix
@@ -42,7 +42,7 @@
     # It gets resolved within the builder itself, and then passed to your
     # categoryDefinitions and packageDefinitions.
 
-    # this allows you to use ${pkgs.system} whenever you want in those sections
+    # this allows you to use ${pkgs.stdenv.hostPlatform.system} whenever you want in those sections
     # without fear.
 
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
@@ -220,7 +220,7 @@
           # IMPORTANT:
           # your alias may not conflict with your other packages.
           # aliases = [ "vim" ];
-          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
           hosts.python3.enable = true;
           hosts.node.enable = true;
         };

--- a/templates/example/flake.nix
+++ b/templates/example/flake.nix
@@ -70,7 +70,7 @@
     # It gets resolved within the builder itself, and then passed to your
     # categoryDefinitions and packageDefinitions.
 
-    # this allows you to use ${pkgs.system} whenever you want in those sections
+    # this allows you to use ${pkgs.stdenv.hostPlatform.system} whenever you want in those sections
     # without fear.
 
     # see :help nixCats.flake.outputs.overlays
@@ -350,7 +350,7 @@
           # OR see :help nixCats.flake.outputs.settings for all of the settings available
           wrapRc = true;
           configDirName = "nixCats-nvim";
-          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
           hosts.python3.enable = true;
           hosts.node.enable = true;
         };
@@ -406,7 +406,7 @@
           aliases = [ "testCat" ];
 
           # If you wanted nightly, uncomment this, and the flake input.
-          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
           # Probably add the cache stuff they recommend too.
         };
         categories = {

--- a/templates/flakeless/default.nix
+++ b/templates/flakeless/default.nix
@@ -100,7 +100,7 @@
         # IMPORTANT:
         # your aliases may not conflict with your other packages.
         aliases = [ "vim" ];
-        # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+        # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
       };
       # and a set of categories that you want
       categories = {

--- a/templates/fresh/flake.nix
+++ b/templates/fresh/flake.nix
@@ -59,7 +59,7 @@
     # It gets resolved within the builder itself, and then passed to your
     # categoryDefinitions and packageDefinitions.
 
-    # this allows you to use ${pkgs.system} whenever you want in those sections
+    # this allows you to use ${pkgs.stdenv.hostPlatform.system} whenever you want in those sections
     # without fear.
 
     # see :help nixCats.flake.outputs.overlays
@@ -174,7 +174,7 @@
           # IMPORTANT:
           # your alias may not conflict with your other packages.
           aliases = [ "vim" ];
-          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
         };
         # and a set of categories that you want
         # (and other information to pass to lua)

--- a/templates/home-manager/default.nix
+++ b/templates/home-manager/default.nix
@@ -143,7 +143,7 @@ in {
             # IMPORTANT:
             # your alias may not conflict with your other packages.
             aliases = [ "vim" "homeVim" ];
-            # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+            # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
             hosts.python3.enable = true;
             hosts.node.enable = true;
           };

--- a/templates/kickstart-nvim/flake.nix
+++ b/templates/kickstart-nvim/flake.nix
@@ -59,7 +59,7 @@
     # It gets resolved within the builder itself, and then passed to your
     # categoryDefinitions and packageDefinitions.
 
-    # this allows you to use ${pkgs.system} whenever you want in those sections
+    # this allows you to use ${pkgs.stdenv.hostPlatform.system} whenever you want in those sections
     # without fear.
 
     dependencyOverlays = /* (import ./overlays inputs) ++ */ [
@@ -241,7 +241,7 @@
           # IMPORTANT:
           # your alias may not conflict with your other packages.
           aliases = [ "vim" ];
-          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+          # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
           hosts.python3.enable = true;
           hosts.node.enable = true;
         };

--- a/templates/nixExpressionFlakeOutputs/default.nix
+++ b/templates/nixExpressionFlakeOutputs/default.nix
@@ -11,7 +11,7 @@
   Then call this file with:
   myNixCats = import ./path/to/this/dir { inherit inputs; };
   And the new variable myNixCats will contain all outputs of the normal flake format.
-  You could put myNixCats.packages.${pkgs.system}.thepackagename in your packages list.
+  You could put myNixCats.packages.${pkgs.stdenv.hostPlatform.system}.thepackagename in your packages list.
   You could install them with the module and reconfigure them too if you want.
   You should definitely re export them under packages.${system}.packagenames
   from your system flake so that you can still run it via nix run from anywhere.
@@ -113,7 +113,7 @@
         # IMPORTANT:
         # your alias may not conflict with your other packages.
         aliases = [ "vim" ];
-        # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+        # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
       };
       # and a set of categories that you want
       # (and other information to pass to lua)

--- a/templates/nixos/default.nix
+++ b/templates/nixos/default.nix
@@ -94,7 +94,7 @@ in {
             # IMPORTANT:
             # your alias may not conflict with your other packages.
             aliases = [ "nvim" ];
-            # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.system}.neovim;
+            # neovim-unwrapped = inputs.neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.neovim;
           };
           # and a set of categories that you want
           # (and other information to pass to lua)


### PR DESCRIPTION
Marked as deprecated in [this upstream nixpkgs commit].

Use `pkgs.stdenv.hostPlatform.system` instead.

[this upstream nixpkgs commit]: https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991#diff-29ed0f5fda84c91253503c1664d60a194a324e29518d472adf846f30b8db52e3R1445