### PR TITLE
fix: nvim-treesitter not working in kickstart template

### DIFF
--- a/templates/kickstart-nvim/flake.nix
+++ b/templates/kickstart-nvim/flake.nix
@@ -135,7 +135,7 @@
           onedark-nvim
           todo-comments-nvim
           mini-nvim
-          nvim-treesitter.withAllGrammars
+          nvim-treesitter
           # This is for if you only want some of the grammars
           # (nvim-treesitter.withPlugins (
           #   plugins: with plugins; [


### PR DESCRIPTION
A simple fix for kickstart-nvim template

## Details
After a flake update treesitter stopped working

## Steps to reproduce
`nix flake init -t github:BirdeeHub/nixCats-nvim#kickstart-nvim`
`nix run . test.nix`

And now the easiest way to check is inserting a comment
