### PR TITLE
fix(builder): replace deprecated stdenv.isLinux with stdenv.hostPlatform.isLinux

### DIFF
--- a/builder/wrapper.nix
+++ b/builder/wrapper.nix
@@ -56,7 +56,7 @@ in {
     mkdir -p $out/nix-support && \
     cp -r ${neovim-unwrapped}/nix-support/* $out/nix-support
   ''
-  + lib.optionalString stdenv.isLinux ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share/applications
     substitute ${lib.escapeShellArgs [ "${neovim-unwrapped}/share/applications/nvim.desktop" "${placeholder "out"}/share/applications/${nixCats_packageName}.desktop"
       "--replace-fail" "Name=Neovim" "Name=${nixCats_packageName}"


### PR DESCRIPTION
## Why

nixpkgs deprecated the `stdenv.is*` aliases, so every evaluation of a nixCats-built package now emits:

```
evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead
```

traced to `builder/wrapper.nix:59` (the Linux `.desktop`-entry block in `buildPhase`).

## How

One-line rename to `stdenv.hostPlatform.isLinux`. `rg 'stdenv\.is[A-Z]'` confirms it was the only remaining deprecated-alias use in the repo.

## Tests

Rebuilt my nixCats package against this branch on aarch64-darwin: evaluation is warning-free and the output is unchanged.